### PR TITLE
feat: forward refs for card components

### DIFF
--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={className} {...props} />
+  )
+);
+Card.displayName = 'Card';
+
+export interface CardContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const CardContent = React.forwardRef<HTMLDivElement, CardContentProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={className} {...props} />
+  )
+);
+CardContent.displayName = 'CardContent';


### PR DESCRIPTION
## Summary
- wrap Card and CardContent in `React.forwardRef`
- forward refs to underlying divs for drag-and-drop compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a073cd0a408320a580d1819cdf9aff