### PR TITLE
Use dynamic base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vite';
 import path from 'path';
 
+// Detect repository name from the GitHub environment to construct the correct
+// base path when deploying to GitHub Pages. This allows the site to work both
+// locally (where `GITHUB_REPOSITORY` is undefined and the base becomes `/`) and
+// on pages (where the repo name is used as the base prefix).
+const repo = process.env.GITHUB_REPOSITORY?.split('/')[1];
+
 export default defineConfig(async () => ({
   plugins: [(await import('@vitejs/plugin-react')).default()],
   resolve: {
@@ -8,6 +14,6 @@ export default defineConfig(async () => ({
       '@': path.resolve(__dirname, '.'),
     },
   },
-  base: '/ED-dashboard/',
+  base: repo ? `/${repo}/` : '/',
 }));
 


### PR DESCRIPTION
## Summary
- compute base path from `GITHUB_REPOSITORY` so the app builds correctly on GitHub Pages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a07e84731c8320813d4235081040ad