### PR TITLE
fix: forward refs in card mock

### DIFF
--- a/__tests__/LovuValdymoPrograma.test.tsx
+++ b/__tests__/LovuValdymoPrograma.test.tsx
@@ -22,10 +22,21 @@ jest.mock(
 
 jest.mock(
   '@/components/ui/card',
-  () => ({
-    Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>
-  }),
+  () => {
+    const React = require('react');
+    return {
+      Card: React.forwardRef<HTMLDivElement, any>(({ children, ...props }, ref) => (
+        <div ref={ref} {...props}>
+          {children}
+        </div>
+      )),
+      CardContent: React.forwardRef<HTMLDivElement, any>(({ children, ...props }, ref) => (
+        <div ref={ref} {...props}>
+          {children}
+        </div>
+      ))
+    };
+  },
   { virtual: true }
 );
 


### PR DESCRIPTION
## Summary
- forward refs in card mock to avoid React warnings in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a09c9458548320a378fe861e84a4f5