### PR TITLE
fix: use relative base path to avoid MIME errors

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ED Dashboard</title>
-    <script type="module" crossorigin src="/ED-dashboard/assets/index-BjXU5oGc.js"></script>
+    <script type="module" crossorigin src="./assets/index-BjXU5oGc.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,9 @@
 import { defineConfig } from 'vite';
 import { fileURLToPath, URL } from 'node:url';
 
-// Detect repository name from the GitHub environment to construct the correct
-// base path when deploying to GitHub Pages. This allows the site to work both
-// locally (where `GITHUB_REPOSITORY` is undefined and the base becomes `/`) and
-// on pages (where the repo name is used as the base prefix).
-const repo = process.env.GITHUB_REPOSITORY?.split('/')[1];
-
+// Use a relative base path so built assets load correctly regardless of where
+// the site is hosted. This avoids servers responding with a generic MIME type
+// for module scripts when an absolute path cannot be resolved.
 export default defineConfig(async () => ({
   plugins: [(await import('@vitejs/plugin-react')).default()],
   resolve: {
@@ -14,7 +11,7 @@ export default defineConfig(async () => ({
       '@': fileURLToPath(new URL('./', import.meta.url)),
     },
   },
-  base: repo ? `/${repo}/` : '/',
+  base: './',
   build: {
     outDir: 'docs',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- ensure Vite build uses a relative base so module scripts load with correct MIME type
- regenerate built `docs` entry to use relative asset path

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0bea8f984832096abaeb8a933639d