### PR TITLE
Add safe JSON parsing helper for localStorage

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Toilet, Brush, Check } from 'lucide-react';
 import Pranesimas from './Pranesimas.jsx';
+import safeParse from './safeParse.jsx';
 
 // ---------------- Konfigūracija -----------------
 const ZONOS = {
@@ -93,23 +94,17 @@ function LovosKortele({ lova, status, onWC, onClean, onCheck }) {
 
 // ------------- Pagrindinis Komponentas ------------
 export default function LovuValdymoPrograma() {
-  const [statusMap,setStatusMap]=useState(()=>{
-    const saugota=localStorage.getItem('lovuBusena');
-    return saugota
-      ? JSON.parse(saugota)
-      : Object.fromEntries(VISOS_LOVOS.map(b=>[b,{...NUMATYTA_BUSENA}]));
-  });
-  const [zonuPadejejas,setZonuPadejejas]=useState(()=>{
-    const saugota=localStorage.getItem('zonuPadejejas');
-    return saugota
-      ? JSON.parse(saugota)
-      : Object.fromEntries(Object.keys(ZONOS).map(z=>[z,'']));
-  });
+  const [statusMap,setStatusMap]=useState(()=>
+    safeParse('lovuBusena',Object.fromEntries(VISOS_LOVOS.map(b=>[b,{...NUMATYTA_BUSENA}])))
+  );
+  const [zonuPadejejas,setZonuPadejejas]=useState(()=>
+    safeParse('zonuPadejejas',Object.fromEntries(Object.keys(ZONOS).map(z=>[z,''])))
+  );
   const [filtras,setFiltras]=useState(FiltravimoRezimai.VISI);
   const [,tick]=useState(0);
   const [snack,setSnack]=useState(null);
   const [skirtukas,setSkirtukas]=useState('lovos');
-  const [zurnalas,setZurnalas]=useState(()=>JSON.parse(localStorage.getItem('lovuZurnalas')||'[]'));
+  const [zurnalas,setZurnalas]=useState(()=>safeParse('lovuZurnalas',[]));
   const [paieska,setPaieska]=useState('');
 
   useEffect(()=>void localStorage.setItem('lovuBusena',JSON.stringify(statusMap)),[statusMap]);

--- a/safeParse.jsx
+++ b/safeParse.jsx
@@ -1,0 +1,11 @@
+export default function safeParse(key, defaultValue) {
+  const raw = localStorage.getItem(key);
+  if (!raw) return defaultValue;
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    console.warn(`Failed to parse localStorage key "${key}"`, error);
+    localStorage.removeItem(key);
+    return defaultValue;
+  }
+}


### PR DESCRIPTION
## Summary
- add `safeParse` helper to read and validate JSON from localStorage
- use `safeParse` for `statusMap`, `zonuPadejejas`, and `zurnalas` initial states

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b88727136883208c07666ed060432d