### PR TITLE
refactor: centralize bed state helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ main.js
 !docs/**/*.js
 !postcss.config.js
 !tailwind.config.js
+!src/**/*.js
 

--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -6,6 +6,7 @@ import useLocalStorageState from './hooks/useLocalStorageState.js';
 import Filters from './components/Filters.jsx';
 import Tabs from './components/Tabs.jsx';
 import ZoneSection from './components/ZoneSection.jsx';
+import { NUMATYTA_BUSENA, dabar } from '@/src/utils/bedState.js';
 
 // ---------------- Konfigūracija -----------------
 const ZONOS = {
@@ -21,17 +22,6 @@ const VISOS_LOVOS = Object.values(ZONOS).flat();
 // ------------- Tipai --------------------
 const FiltravimoRezimai = { VISI: 'VISI', TUALETAS: 'TUALETAS', VALYMAS: 'VALYMAS', UZDELTAS: 'UZDELTAS' };
 
-const NUMATYTA_BUSENA = {
-  needsWC: false,
-  needsCleaning: false,
-  flaggedAt: null,
-  lastBy: null,
-  lastAt: null,
-  lastCheckedAt: null,
-  lastWCAt: null,
-  lastCleanAt: null,
-};
-const dabar = () => Date.now();
 
 // ------------- Pagrindinis Komponentas ------------
 export default function LovuValdymoPrograma() {

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -4,24 +4,7 @@ import { Droppable, Draggable } from 'react-beautiful-dnd';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Toilet, Brush, Check } from 'lucide-react';
-
-const NUMATYTA_BUSENA = {
-  needsWC: false,
-  needsCleaning: false,
-  flaggedAt: null,
-  lastBy: null,
-  lastAt: null,
-  lastCheckedAt: null,
-  lastWCAt: null,
-  lastCleanAt: null,
-};
-const dabar = () => Date.now();
-const laikasFormatu = t => {
-  const secs = Math.floor((dabar() - t) / 1000);
-  const m = Math.floor(secs / 60);
-  const s = secs % 60;
-  return `${m}:${String(s).padStart(2,'0')}`;
-};
+import { NUMATYTA_BUSENA, dabar, laikasFormatu } from '@/src/utils/bedState.js';
 
 function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
   const s = status || NUMATYTA_BUSENA;

--- a/src/utils/bedState.js
+++ b/src/utils/bedState.js
@@ -1,0 +1,21 @@
+export const NUMATYTA_BUSENA = {
+  needsWC: false,
+  needsCleaning: false,
+  flaggedAt: null,
+  lastBy: null,
+  lastAt: null,
+  lastCheckedAt: null,
+  lastWCAt: null,
+  lastCleanAt: null,
+};
+
+export const dabar = () => Date.now();
+
+export const laikasFormatu = t => {
+  const secs = Math.floor((dabar() - t) / 1000);
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return `${m}:${String(s).padStart(2,'0')}`;
+};
+
+export default { NUMATYTA_BUSENA, dabar, laikasFormatu };


### PR DESCRIPTION
## Summary
- consolidate bed state constants and helpers into `src/utils/bedState.js`
- import shared bed state utilities in `LovuValdymoPrograma` and `ZoneSection`
- allow tracking JS utilities under `src` in `.gitignore`

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b92db609b08320a6568ed48779110d