### PR TITLE
Add standard ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,5 @@
-node_modules
-dist
+node_modules/
+.DS_Store
+dist/
+docs/
 assets/
-
-# Ignore built JavaScript bundles
-main.js
-*.js
-
-# Keep built files for GitHub Pages
-!docs/**/*.js
-!postcss.config.js
-!tailwind.config.js
-!src/**/*.js
-


### PR DESCRIPTION
## Summary
- Ignore node modules, macOS artefacts, build outputs, docs, and assets with a new `.gitignore`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b9301f67b48320989d5c96d66ffa96