### PR TITLE
chore: add npm registry configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary
- add `.npmrc` to point npm to `https://registry.npmjs.org/`

## Testing
- `npm cache clean --force`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b933f824188320a1542f7ddac6b416