### PR TITLE
refactor tests: centralize shared mocks

### DIFF
--- a/__tests__/LovuValdymoPrograma.test.jsx
+++ b/__tests__/LovuValdymoPrograma.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent, screen, within, act } from '@testing-library/react';
+import { dndOnDragEnd } from './testUtils/mocks';
 
 jest.mock(
   'react-swipeable',
@@ -9,50 +10,6 @@ jest.mock(
   { virtual: true }
 );
 
-let dndOnDragEnd;
-jest.mock(
-  'react-beautiful-dnd',
-  () => {
-    const React = require('react');
-    return {
-      DragDropContext: ({ children, onDragEnd }) => {
-        dndOnDragEnd = onDragEnd;
-        return <div>{children}</div>;
-      },
-      Droppable: ({ children }) => (
-        <div>{children({ innerRef: jest.fn(), droppableProps: {}, placeholder: null })}</div>
-      ),
-      Draggable: ({ children }) => (
-        <div>{children({ innerRef: jest.fn(), draggableProps: {}, dragHandleProps: {} })}</div>
-      )
-    };
-  },
-  { virtual: true }
-);
-
-jest.mock(
-  '@/components/ui/card',
-  () => {
-    const React = require('react');
-    return {
-      Card: React.forwardRef(({ children, ...props }, ref) => (
-        <div ref={ref} {...props}>{children}</div>
-      )),
-      CardContent: React.forwardRef(({ children, ...props }, ref) => (
-        <div ref={ref} {...props}>{children}</div>
-      ))
-    };
-  },
-  { virtual: true }
-);
-
-jest.mock(
-  '@/components/ui/button',
-  () => ({
-    Button: ({ children, ...props }) => <button {...props}>{children}</button>
-  }),
-  { virtual: true }
-);
 import LovuValdymoPrograma from '../LovuValdymoPrograma.jsx';
 
 jest.useFakeTimers();

--- a/__tests__/testUtils/mocks.js
+++ b/__tests__/testUtils/mocks.js
@@ -1,0 +1,47 @@
+import React from 'react';
+
+export let dndOnDragEnd;
+
+jest.mock(
+  'react-beautiful-dnd',
+  () => {
+    const React = require('react');
+    return {
+      DragDropContext: ({ children, onDragEnd }) => {
+        dndOnDragEnd = onDragEnd;
+        return <div>{children}</div>;
+      },
+      Droppable: ({ children }) => (
+        <div>{children({ innerRef: jest.fn(), droppableProps: {}, placeholder: null })}</div>
+      ),
+      Draggable: ({ children }) => (
+        <div>{children({ innerRef: jest.fn(), draggableProps: {}, dragHandleProps: {} })}</div>
+      )
+    };
+  },
+  { virtual: true }
+);
+
+jest.mock(
+  '@/components/ui/card',
+  () => {
+    const React = require('react');
+    return {
+      Card: React.forwardRef(({ children, ...props }, ref) => (
+        <div ref={ref} {...props}>{children}</div>
+      )),
+      CardContent: React.forwardRef(({ children, ...props }, ref) => (
+        <div ref={ref} {...props}>{children}</div>
+      ))
+    };
+  },
+  { virtual: true }
+);
+
+jest.mock(
+  '@/components/ui/button',
+  () => ({
+    Button: ({ children, ...props }) => <button {...props}>{children}</button>
+  }),
+  { virtual: true }
+);


### PR DESCRIPTION
## Summary
- add shared Jest mocks for `react-beautiful-dnd` and UI components
- simplify `LovuValdymoPrograma.test.jsx` by importing shared mocks

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b93ed3b2c483209f4419fc066b90a6