### PR TITLE
refactor: use Tailwind responsive sizing

### DIFF
--- a/__tests__/ZoneSection.test.jsx
+++ b/__tests__/ZoneSection.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { DragDropContext } from 'react-beautiful-dnd';
+import ZoneSection from '../components/ZoneSection.jsx';
+
+jest.mock(
+  'react-swipeable',
+  () => ({
+    useSwipeable: () => ({})
+  }),
+  { virtual: true }
+);
+
+const renderZone = () =>
+  render(
+    <DragDropContext onDragEnd={() => {}}>
+      <ZoneSection
+        zona="Test"
+        lovos={['1']}
+        statusMap={{}}
+        applyFilter={() => true}
+        onWC={() => {}}
+        onClean={() => {}}
+        onCheck={() => {}}
+        padejejas=""
+        onPadejejasChange={() => {}}
+        checkAll={() => {}}
+      />
+    </DragDropContext>
+  );
+
+describe('ZoneSection responsiveness', () => {
+  afterEach(() => cleanup());
+
+  test('uses base size classes on small screens', () => {
+    window.innerWidth = 500;
+    renderZone();
+    const card = screen.getByText('1').closest('.bg-gray-200');
+    expect(card).toHaveClass('w-20', 'h-24');
+  });
+
+  test('includes larger size classes for sm breakpoint', () => {
+    window.innerWidth = 700;
+    renderZone();
+    const card = screen.getByText('1').closest('.bg-gray-200');
+    expect(card).toHaveClass('sm:w-24', 'sm:h-28');
+  });
+});

--- a/__tests__/testUtils/mocks.js
+++ b/__tests__/testUtils/mocks.js
@@ -45,3 +45,8 @@ jest.mock(
   }),
   { virtual: true }
 );
+
+// Placeholder test to satisfy Jest's requirement for at least one test in this file.
+test('test utils mocks are defined', () => {
+  expect(dndOnDragEnd).toBeUndefined();
+});

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -14,7 +14,6 @@ function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
     delta: 50,
   });
   const pradelsta = s.lastCheckedAt ? (dabar() - s.lastCheckedAt) > 30*60*1000 : true;
-  const fonas = '#E2E8F0';
   const rysys = lova.startsWith('IT')
     ? 'border-2 border-blue-400'
     : pradelsta
@@ -31,8 +30,7 @@ function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
-          className={`m-1 p-1 w-[80px] h-[105px] ${rysys}`}
-          style={{ backgroundColor: fonas }}
+          className={`m-1 p-1 w-20 h-24 sm:w-24 sm:h-28 bg-gray-200 ${rysys}`}
           title={s.lastBy ? `${s.lastBy} • ${new Date(s.lastAt).toLocaleTimeString()}` : ''}
         >
           <CardContent className="p-1 flex flex-col items-center h-full space-y-0.5">


### PR DESCRIPTION
## Summary
- style bed cards with Tailwind utilities and responsive widths/heights
- add tests ensuring bed card uses responsive classes
- add placeholder test for mocks file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9452c9adc83209f7cfffdd0623531