### PR TITLE
Use responsive sizing for zone cards

### DIFF
--- a/__tests__/ZoneSection.test.jsx
+++ b/__tests__/ZoneSection.test.jsx
@@ -32,17 +32,10 @@ const renderZone = () =>
 describe('ZoneSection responsiveness', () => {
   afterEach(() => cleanup());
 
-  test('uses base size classes on small screens', () => {
-    window.innerWidth = 500;
+  test('applies responsive sizing utilities', () => {
     renderZone();
     const card = screen.getByText('1').closest('.bg-gray-200');
-    expect(card).toHaveClass('w-full', 'h-24');
-  });
-
-  test('includes larger size classes for sm breakpoint', () => {
-    window.innerWidth = 700;
-    renderZone();
-    const card = screen.getByText('1').closest('.bg-gray-200');
-    expect(card).toHaveClass('w-full', 'sm:h-28');
+    expect(card).toHaveClass('w-full', 'max-w-[6rem]', 'aspect-[3/4]');
+    expect(card).not.toHaveClass('h-24', 'sm:h-28');
   });
 });

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -30,7 +30,7 @@ function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
-          className={`p-1 w-full h-24 sm:h-28 bg-gray-200 ${rysys}`}
+          className={`p-1 w-full max-w-[6rem] aspect-[3/4] bg-gray-200 ${rysys}`}
           title={s.lastBy ? `${s.lastBy} • ${new Date(s.lastAt).toLocaleTimeString()}` : ''}
         >
           <CardContent className="p-1 flex flex-col items-center h-full space-y-0.5">
@@ -90,7 +90,7 @@ export default function ZoneSection({
       </div>
       <Droppable droppableId={zona}>
         {provided => (
-          <div ref={provided.innerRef} {...provided.droppableProps} className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2">
+            <div ref={provided.innerRef} {...provided.droppableProps} className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2 justify-items-center">
             {lovos.filter(applyFilter).map((l, i) => (
               <LovosKortele
                 key={l}


### PR DESCRIPTION
## Summary
- Replace fixed card heights with responsive width and aspect ratio utilities
- Center cards within grid for uniform scaling
- Update ZoneSection tests for new responsive classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b949d2511c83208193a7e743b91ee7