### PR TITLE
refactor: centralize theme colors in CSS variables

### DIFF
--- a/index.css
+++ b/index.css
@@ -3,9 +3,16 @@
 @tailwind utilities;
 
 /* Global stylesheet */
+/* Theme variables */
+:root {
+  /* default light theme colors */
+  --color-text-primary: #1f2937; /* gray-800 */
+  --color-bg-primary: #f1f5f9; /* gray-100 */
+}
+
 body {
   margin: 0;
   font-family: system-ui, sans-serif;
-  color: #1f2937; /* gray-800 */
-  background-color: #f1f5f9; /* gray-100 */
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
 }


### PR DESCRIPTION
## Summary
- define `--color-text-primary` and `--color-bg-primary` on `:root`
- apply these CSS variables in the global `body` styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9527e9af483208c0437458de1f06e