### PR TITLE
Add color-coded bed status visuals

### DIFF
--- a/__tests__/ZoneSection.test.jsx
+++ b/__tests__/ZoneSection.test.jsx
@@ -35,14 +35,14 @@ describe('ZoneSection responsiveness', () => {
   test('uses base size classes on small screens', () => {
     window.innerWidth = 500;
     renderZone();
-    const card = screen.getByText('1').closest('.bg-gray-200');
+    const card = screen.getByText('1').closest('.bg-red-100');
     expect(card).toHaveClass('w-full', 'h-24');
   });
 
   test('includes larger size classes for sm breakpoint', () => {
     window.innerWidth = 700;
     renderZone();
-    const card = screen.getByText('1').closest('.bg-gray-200');
+    const card = screen.getByText('1').closest('.bg-red-100');
     expect(card).toHaveClass('w-full', 'sm:h-28');
   });
 });

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -14,13 +14,18 @@ function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
     delta: 50,
   });
   const pradelsta = s.lastCheckedAt ? (dabar() - s.lastCheckedAt) > 30*60*1000 : true;
+  // Color legend:
+  // - Blue: IT beds
+  // - Red: overdue check
+  // - Green: needs WC or cleaning
+  // - Gray: normal status
   const rysys = lova.startsWith('IT')
-    ? 'border-2 border-blue-400'
+    ? 'border-2 border-blue-400 bg-blue-100 text-blue-800'
     : pradelsta
-      ? 'animate-pulse border-2 border-red-500'
+      ? 'animate-pulse border-2 border-red-500 bg-red-100 text-red-800'
       : s.needsWC || s.needsCleaning
-        ? 'border-2 border-blue-400 animate-pulse'
-        : '';
+        ? 'border-2 border-green-400 bg-green-100 text-green-800 animate-pulse'
+        : 'bg-gray-200';
 
   return (
     <Draggable draggableId={lova} index={index}>
@@ -30,7 +35,7 @@ function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
-          className={`p-1 w-full h-24 sm:h-28 bg-gray-200 ${rysys}`}
+          className={`p-1 w-full h-24 sm:h-28 ${rysys}`}
           title={s.lastBy ? `${s.lastBy} • ${new Date(s.lastAt).toLocaleTimeString()}` : ''}
         >
           <CardContent className="p-1 flex flex-col items-center h-full space-y-0.5">


### PR DESCRIPTION
## Summary
- add background and text colors to bed state logic with a color legend
- adjust ZoneSection tests for new color-coded statuses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b954af4cec8320ad8ed98cadc6847e