### PR TITLE
feat: add success and warning button variants

### DIFF
--- a/components/Filters.jsx
+++ b/components/Filters.jsx
@@ -7,7 +7,14 @@ export default function Filters({ filtras, setFiltras, FiltravimoRezimai }) {
       <Button className="flex-1 text-center" size="sm" onClick={() => setFiltras(FiltravimoRezimai.VISI)} variant={filtras===FiltravimoRezimai.VISI?'default':'outline'}>Visi</Button>
       <Button className="flex-1 text-center" size="sm" onClick={() => setFiltras(FiltravimoRezimai.TUALETAS)} variant={filtras===FiltravimoRezimai.TUALETAS?'default':'outline'}>Tualetas</Button>
       <Button className="flex-1 text-center" size="sm" onClick={() => setFiltras(FiltravimoRezimai.VALYMAS)} variant={filtras===FiltravimoRezimai.VALYMAS?'default':'outline'}>Valymas</Button>
-      <Button className="flex-1 text-center" size="sm" onClick={() => setFiltras(FiltravimoRezimai.UZDELTAS)} variant={filtras===FiltravimoRezimai.UZDELTAS?'default':'outline'}>Pradelstos</Button>
+      <Button
+        className="flex-1 text-center"
+        size="sm"
+        onClick={() => setFiltras(FiltravimoRezimai.UZDELTAS)}
+        variant={filtras===FiltravimoRezimai.UZDELTAS?'warning':'outline'}
+      >
+        Pradelstos
+      </Button>
     </div>
   );
 }

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -44,13 +44,37 @@ function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
             {s.lastWCAt && <span className="text-[7px]">Tual.: {laikasFormatu(s.lastWCAt)}</span>}
             {s.lastCleanAt && <span className="text-[7px]">Val.: {laikasFormatu(s.lastCleanAt)}</span>}
             <div className="flex gap-1 mt-auto">
-              <Button size="icon" className="w-5 h-5" variant={s.needsWC?'destructive':'outline'} onClick={e=>{e.stopPropagation(); onWC(lova);}}>
+              <Button
+                size="icon"
+                className="w-5 h-5"
+                variant={s.needsWC ? 'warning' : 'outline'}
+                onClick={e => {
+                  e.stopPropagation();
+                  onWC(lova);
+                }}
+              >
                 <Toilet size={12}/>
               </Button>
-              <Button size="icon" className="w-5 h-5" variant={s.needsCleaning?'destructive':'outline'} onClick={e=>{e.stopPropagation(); onClean(lova);}}>
+              <Button
+                size="icon"
+                className="w-5 h-5"
+                variant={s.needsCleaning ? 'warning' : 'outline'}
+                onClick={e => {
+                  e.stopPropagation();
+                  onClean(lova);
+                }}
+              >
                 <Brush size={12}/>
               </Button>
-              <Button size="icon" className="w-5 h-5" variant="outline" onClick={e=>{e.stopPropagation(); onCheck(lova);}}>
+              <Button
+                size="icon"
+                className="w-5 h-5"
+                variant={pradelsta ? 'warning' : 'success'}
+                onClick={e => {
+                  e.stopPropagation();
+                  onCheck(lova);
+                }}
+              >
                 <Check size={12}/>
               </Button>
             </div>
@@ -85,7 +109,7 @@ export default function ZoneSection({
         />
         <Button
           size="icon"
-          variant="outline"
+          variant="success"
           onClick={checkAll}
           aria-label="Patikrinti visus"
           className="flex-shrink-0"

--- a/components/ui/button.jsx
+++ b/components/ui/button.jsx
@@ -2,9 +2,16 @@ import * as React from 'react';
 
 /**
  * Minimal button component with a few opinionated styles so the UI
- * has a consistent look across the app. Variants roughly follow the
- * names used throughout the project (`default`, `outline`,
- * `destructive`) and a couple of sizes are supported.
+ * has a consistent look across the app.
+ *
+ * Available variants:
+ * - `default`: primary action (blue)
+ * - `outline`: bordered neutral action
+ * - `destructive`: dangerous action (red)
+ * - `success`: positive action/confirmation (green)
+ * - `warning`: cautionary action (yellow)
+ *
+ * A couple of sizes are supported.
  */
 export const Button = React.forwardRef(
   ({ className = '', variant = 'default', size = 'md', ...props }, ref) => {
@@ -15,6 +22,8 @@ export const Button = React.forwardRef(
       outline:
         'border border-gray-300 text-gray-700 bg-white hover:bg-gray-50',
       destructive: 'bg-red-600 text-white hover:bg-red-700',
+      success: 'bg-green-600 text-white hover:bg-green-700',
+      warning: 'bg-yellow-500 text-white hover:bg-yellow-600',
     };
     const sizes = {
       sm: 'px-2 py-1 text-xs',
@@ -34,4 +43,6 @@ export const Button = React.forwardRef(
   }
 );
 Button.displayName = 'Button';
+
+export default Button;
 


### PR DESCRIPTION
## Summary
- extend Button with success and warning variants
- use new variants in filters and zone controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9560910788320a22f40e71f376f0e