### PR TITLE
feat: enable dark mode

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -40,6 +40,9 @@ export default function LovuValdymoPrograma() {
   const [skirtukas,setSkirtukas]=useState('lovos');
   const [zurnalas,setZurnalas]=useLocalStorageState('lovuZurnalas',[]);
   const [paieska,setPaieska]=useState('');
+  const [dark,setDark]=useState(false);
+
+  useEffect(()=>{document.documentElement.classList.toggle('dark',dark);},[dark]);
   
   useEffect(()=>{const id=setInterval(()=>tick(x=>x+1),1000);return()=>clearInterval(id)},[]);
 
@@ -64,7 +67,8 @@ export default function LovuValdymoPrograma() {
 
   return(
     <div className="mx-auto max-w-screen-xl">
-      <div className="p-2 bg-gray-100 min-h-screen">
+      <div className="p-2 bg-gray-100 dark:bg-gray-900 min-h-screen">
+        <Button size="sm" className="fixed top-2 right-2" onClick={()=>setDark(d=>!d)}>{dark? 'Light':'Dark'}</Button>
         <Filters filtras={filtras} setFiltras={setFiltras} FiltravimoRezimai={FiltravimoRezimai}/>
         <Tabs skirtukas={skirtukas} setSkirtukas={setSkirtukas}/>
         {skirtukas==='lovos'?(
@@ -88,7 +92,7 @@ export default function LovuValdymoPrograma() {
         ):(
           <div>
             <div className="flex items-center gap-2 mb-1">
-              <input className="border p-1 rounded text-xs flex-1" placeholder="Ieškoti žurnale" value={paieska} onChange={e=>setPaieska(e.target.value)}/>
+              <input className="border p-1 rounded text-xs flex-1 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100" placeholder="Ieškoti žurnale" value={paieska} onChange={e=>setPaieska(e.target.value)}/>
               <Button size="sm" onClick={exportCsv}>Eksportuoti CSV</Button>
             </div>
             <ul className="text-xs space-y-1 max-h-[70vh] overflow-auto">

--- a/Pranesimas.jsx
+++ b/Pranesimas.jsx
@@ -10,7 +10,7 @@ export default function Pranesimas({ msg, onUndo }) {
   }, [msg]);
   if (!rodoma) return null;
   return (
-    <div className="fixed bottom-1 left-1/2 -translate-x-1/2 bg-gray-800 text-white px-2 py-0.5 rounded flex items-center gap-1 text-[10px] z-50">
+    <div className="fixed bottom-1 left-1/2 -translate-x-1/2 bg-gray-800 text-white dark:bg-gray-100 dark:text-gray-800 px-2 py-0.5 rounded flex items-center gap-1 text-[10px] z-50">
       {msg}
       <button onClick={onUndo} className="underline"><Undo2 size={10}/></button>
     </div>

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -19,13 +19,13 @@ function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
   // - Red: overdue check
   // - Green: needs WC or cleaning
   // - Gray: normal status
-  const rysys = lova.startsWith('IT')
-    ? 'border-2 border-blue-400 bg-blue-100 text-blue-800'
-    : pradelsta
-      ? 'animate-pulse border-2 border-red-500 bg-red-100 text-red-800'
-      : s.needsWC || s.needsCleaning
-        ? 'border-2 border-green-400 bg-green-100 text-green-800 animate-pulse'
-        : 'bg-gray-200';
+    const rysys = lova.startsWith('IT')
+      ? 'border-2 border-blue-400 bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100'
+      : pradelsta
+        ? 'animate-pulse border-2 border-red-500 bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100 dark:border-red-400'
+        : s.needsWC || s.needsCleaning
+          ? 'border-2 border-green-400 bg-green-100 text-green-800 animate-pulse dark:bg-green-900 dark:text-green-100 dark:border-green-400'
+          : 'bg-gray-200 dark:bg-gray-700 dark:text-gray-100';
 
   return (
     <Draggable draggableId={lova} index={index}>
@@ -102,7 +102,7 @@ export default function ZoneSection({
       <div className="flex items-center mb-1 gap-2">
         <h2 className="font-semibold text-xs flex-1 min-w-0 text-left truncate">{zona}</h2>
         <input
-          className="border p-1 text-xs rounded flex-1 min-w-0"
+          className="border p-1 text-xs rounded flex-1 min-w-0 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
           placeholder="Padėjėjas"
           value={padejejas}
           onChange={e => onPadejejasChange(e.target.value)}

--- a/components/ui/button.jsx
+++ b/components/ui/button.jsx
@@ -16,15 +16,15 @@ import * as React from 'react';
 export const Button = React.forwardRef(
   ({ className = '', variant = 'default', size = 'md', ...props }, ref) => {
     const base =
-      'rounded font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none';
-    const variants = {
-      default: 'bg-blue-600 text-white hover:bg-blue-700',
-      outline:
-        'border border-gray-300 text-gray-700 bg-white hover:bg-gray-50',
-      destructive: 'bg-red-600 text-white hover:bg-red-700',
-      success: 'bg-green-600 text-white hover:bg-green-700',
-      warning: 'bg-yellow-500 text-white hover:bg-yellow-600',
-    };
+      'rounded font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 disabled:pointer-events-none';
+      const variants = {
+        default: 'bg-blue-600 text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600',
+        outline:
+          'border border-gray-300 text-gray-700 bg-white hover:bg-gray-50 dark:border-gray-600 dark:text-gray-100 dark:bg-gray-800 dark:hover:bg-gray-700',
+        destructive: 'bg-red-600 text-white hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600',
+        success: 'bg-green-600 text-white hover:bg-green-700 dark:bg-green-500 dark:hover:bg-green-600',
+        warning: 'bg-yellow-500 text-white hover:bg-yellow-600 dark:bg-yellow-600 dark:hover:bg-yellow-700',
+      };
     const sizes = {
       sm: 'px-2 py-1 text-xs',
       md: 'px-3 py-2 text-sm',

--- a/components/ui/card.jsx
+++ b/components/ui/card.jsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 export const Card = React.forwardRef(({ className = '', ...props }, ref) => (
   <div
     ref={ref}
-    className={`bg-white rounded shadow ${className}`.trim()}
+    className={`bg-white dark:bg-gray-800 rounded shadow ${className}`.trim()}
     {...props}
   />
 ));
@@ -18,7 +18,7 @@ export const CardContent = React.forwardRef(
   ({ className = '', ...props }, ref) => (
     <div
       ref={ref}
-      className={`p-2 text-gray-800 ${className}`.trim()}
+      className={`p-2 text-gray-800 dark:text-gray-100 ${className}`.trim()}
       {...props}
     />
   )

--- a/index.css
+++ b/index.css
@@ -3,16 +3,8 @@
 @tailwind utilities;
 
 /* Global stylesheet */
-/* Theme variables */
-:root {
-  /* default light theme colors */
-  --color-text-primary: #1f2937; /* gray-800 */
-  --color-bg-primary: #f1f5f9; /* gray-100 */
-}
-
 body {
   margin: 0;
   font-family: system-ui, sans-serif;
-  color: var(--color-text-primary);
-  background-color: var(--color-bg-primary);
+  @apply text-gray-800 bg-gray-100 dark:text-gray-100 dark:bg-gray-900;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./**/*.{js,jsx,ts,tsx}",


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind
- apply dark theme styling to global styles and components
- add toggle button to switch themes

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b956b11dd48320ac72ef8f1fa6db23