### PR TITLE
Introduce reusable CardHeader and CardFooter components

### DIFF
--- a/__tests__/LovuValdymoPrograma.test.jsx
+++ b/__tests__/LovuValdymoPrograma.test.jsx
@@ -23,7 +23,8 @@ describe('LovuValdymoPrograma', () => {
     render(<LovuValdymoPrograma />);
 
     const bed1Label = screen.getByText(/^1$/);
-    const wcButton = within(bed1Label.parentElement).getAllByRole('button')[0];
+    const card = bed1Label.parentElement.parentElement;
+    const wcButton = within(card).getAllByRole('button')[0];
     fireEvent.click(wcButton);
 
     fireEvent.click(screen.getByText('Tualetas'));
@@ -36,7 +37,8 @@ describe('LovuValdymoPrograma', () => {
     render(<LovuValdymoPrograma />);
 
     const bed1Label = screen.getByText(/^1$/);
-    const wcButton = within(bed1Label.parentElement).getAllByRole('button')[0];
+    const card = bed1Label.parentElement.parentElement;
+    const wcButton = within(card).getAllByRole('button')[0];
     fireEvent.click(wcButton);
 
     fireEvent.click(screen.getByText('Tualetas'));
@@ -59,7 +61,8 @@ describe('LovuValdymoPrograma', () => {
     expect(input.value).toBe('Jonas');
 
     const bed1Label = screen.getByText(/^1$/);
-    expect(within(bed1Label.parentElement).getByText(/Patikrinta/)).toBeInTheDocument();
+    const card = bed1Label.parentElement.parentElement;
+    expect(within(card).getByText(/Patikrinta/)).toBeInTheDocument();
   });
 
   test('dragging moves bed between zones', () => {

--- a/__tests__/testUtils/mocks.js
+++ b/__tests__/testUtils/mocks.js
@@ -30,9 +30,15 @@ jest.mock(
       Card: React.forwardRef(({ children, ...props }, ref) => (
         <div ref={ref} {...props}>{children}</div>
       )),
+      CardHeader: React.forwardRef(({ children, ...props }, ref) => (
+        <div ref={ref} {...props}>{children}</div>
+      )),
       CardContent: React.forwardRef(({ children, ...props }, ref) => (
         <div ref={ref} {...props}>{children}</div>
-      ))
+      )),
+      CardFooter: React.forwardRef(({ children, ...props }, ref) => (
+        <div ref={ref} {...props}>{children}</div>
+      )),
     };
   },
   { virtual: true }

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSwipeable } from 'react-swipeable';
 import { Droppable, Draggable } from 'react-beautiful-dnd';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardHeader, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Toilet, Brush, Check, ChevronDown, ChevronRight } from 'lucide-react';
 import { NUMATYTA_BUSENA, dabar, laikasFormatu } from '@/src/utils/bedState.js';
@@ -35,50 +35,58 @@ function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
-          className={`p-1 w-full h-24 sm:h-28 ${rysys}`}
+          className={`flex flex-col p-1 w-full h-24 sm:h-28 ${rysys}`}
           title={s.lastBy ? `${s.lastBy} • ${new Date(s.lastAt).toLocaleTimeString()}` : ''}
         >
-          <CardContent className="p-1 flex flex-col items-center h-full space-y-0.5">
+          <CardHeader className="p-1 flex justify-center">
             <span className="font-bold text-xs leading-tight">{lova}</span>
-            {s.lastCheckedAt && <span className="text-[7px]">Patikrinta: {laikasFormatu(s.lastCheckedAt)}</span>}
-            {s.lastWCAt && <span className="text-[7px]">Tual.: {laikasFormatu(s.lastWCAt)}</span>}
-            {s.lastCleanAt && <span className="text-[7px]">Val.: {laikasFormatu(s.lastCleanAt)}</span>}
-            <div className="flex gap-1 mt-auto">
-              <Button
-                size="icon"
-                className="w-5 h-5"
-                variant={s.needsWC ? 'warning' : 'outline'}
-                onClick={e => {
-                  e.stopPropagation();
-                  onWC(lova);
-                }}
-              >
-                <Toilet size={12}/>
-              </Button>
-              <Button
-                size="icon"
-                className="w-5 h-5"
-                variant={s.needsCleaning ? 'warning' : 'outline'}
-                onClick={e => {
-                  e.stopPropagation();
-                  onClean(lova);
-                }}
-              >
-                <Brush size={12}/>
-              </Button>
-              <Button
-                size="icon"
-                className="w-5 h-5"
-                variant={pradelsta ? 'warning' : 'success'}
-                onClick={e => {
-                  e.stopPropagation();
-                  onCheck(lova);
-                }}
-              >
-                <Check size={12}/>
-              </Button>
-            </div>
+          </CardHeader>
+          <CardContent className="p-1 flex flex-col items-center flex-1 space-y-0.5">
+            {s.lastCheckedAt && (
+              <span className="text-[7px]">Patikrinta: {laikasFormatu(s.lastCheckedAt)}</span>
+            )}
+            {s.lastWCAt && (
+              <span className="text-[7px]">Tual.: {laikasFormatu(s.lastWCAt)}</span>
+            )}
+            {s.lastCleanAt && (
+              <span className="text-[7px]">Val.: {laikasFormatu(s.lastCleanAt)}</span>
+            )}
           </CardContent>
+          <CardFooter className="p-1 flex gap-1 justify-center">
+            <Button
+              size="icon"
+              className="w-5 h-5"
+              variant={s.needsWC ? 'warning' : 'outline'}
+              onClick={e => {
+                e.stopPropagation();
+                onWC(lova);
+              }}
+            >
+              <Toilet size={12}/>
+            </Button>
+            <Button
+              size="icon"
+              className="w-5 h-5"
+              variant={s.needsCleaning ? 'warning' : 'outline'}
+              onClick={e => {
+                e.stopPropagation();
+                onClean(lova);
+              }}
+            >
+              <Brush size={12}/>
+            </Button>
+            <Button
+              size="icon"
+              className="w-5 h-5"
+              variant={pradelsta ? 'warning' : 'success'}
+              onClick={e => {
+                e.stopPropagation();
+                onCheck(lova);
+              }}
+            >
+              <Check size={12}/>
+            </Button>
+          </CardFooter>
         </Card>
       )}
     </Draggable>

--- a/components/ui/card.jsx
+++ b/components/ui/card.jsx
@@ -14,6 +14,17 @@ export const Card = React.forwardRef(({ className = '', ...props }, ref) => (
 ));
 Card.displayName = 'Card';
 
+export const CardHeader = React.forwardRef(
+  ({ className = '', ...props }, ref) => (
+    <div
+      ref={ref}
+      className={`p-4 border-b border-gray-200 dark:border-gray-700 ${className}`.trim()}
+      {...props}
+    />
+  )
+);
+CardHeader.displayName = 'CardHeader';
+
 export const CardContent = React.forwardRef(
   ({ className = '', ...props }, ref) => (
     <div
@@ -24,4 +35,15 @@ export const CardContent = React.forwardRef(
   )
 );
 CardContent.displayName = 'CardContent';
+
+export const CardFooter = React.forwardRef(
+  ({ className = '', ...props }, ref) => (
+    <div
+      ref={ref}
+      className={`p-4 border-t border-gray-200 dark:border-gray-700 ${className}`.trim()}
+      {...props}
+    />
+  )
+);
+CardFooter.displayName = 'CardFooter';
 


### PR DESCRIPTION
## Summary
- add `CardHeader` and `CardFooter` components using `React.forwardRef` with default border and padding
- refactor bed card layout to use the new header and footer for consistent styling
- update tests and mocks for new card structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96773ed148320bb0cb0ae90fc836e