### PR TITLE
Make ZoneSection cards responsive

### DIFF
--- a/__tests__/ZoneSection.test.jsx
+++ b/__tests__/ZoneSection.test.jsx
@@ -36,14 +36,14 @@ describe('ZoneSection responsiveness', () => {
     window.innerWidth = 500;
     renderZone();
     const card = screen.getByText('1').closest('.bg-red-100');
-    expect(card).toHaveClass('w-full', 'h-28');
+    expect(card).toHaveClass('w-full', 'min-h-28', 'h-auto');
   });
 
   test('includes larger size classes for sm breakpoint', () => {
     window.innerWidth = 700;
     renderZone();
     const card = screen.getByText('1').closest('.bg-red-100');
-    expect(card).toHaveClass('w-full', 'sm:h-32');
+    expect(card).toHaveClass('w-full', 'min-h-28', 'sm:min-h-32', 'h-auto');
   });
 });
 

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -35,7 +35,7 @@ function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
-          className={`flex flex-col p-2 w-full h-28 sm:h-32 hover:scale-105 transition-transform ${rysys}`}
+          className={`flex flex-col p-2 w-full min-h-28 sm:min-h-32 h-auto hover:scale-105 transition-transform ${rysys}`}
           title={s.lastBy ? `${s.lastBy} • ${new Date(s.lastAt).toLocaleTimeString()}` : ''}
         >
           <CardHeader className="p-1 flex justify-center">


### PR DESCRIPTION
## Summary
- Replace fixed heights with responsive min-height and auto sizing in `ZoneSection` card
- Update tests for new responsive class names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b98d082fa88320b6e9bd058496495c