### PR TITLE
refactor: centralize overdue check

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -6,7 +6,7 @@ import useLocalStorageState from './hooks/useLocalStorageState.js';
 import Filters from './components/Filters.jsx';
 import Tabs from './components/Tabs.jsx';
 import ZoneSection from './components/ZoneSection.jsx';
-import { NUMATYTA_BUSENA, dabar } from '@/src/utils/bedState.js';
+import { NUMATYTA_BUSENA, dabar, isOverdue } from '@/src/utils/bedState.js';
 
 // ---------------- Konfigūracija -----------------
 const ZONOS = {
@@ -51,7 +51,7 @@ export default function LovuValdymoPrograma() {
     const s=statusMap[lov]||NUMATYTA_BUSENA;
     if(filtras===FiltravimoRezimai.TUALETAS) return s.needsWC;
     if(filtras===FiltravimoRezimai.VALYMAS) return s.needsCleaning;
-    if(filtras===FiltravimoRezimai.UZDELTAS) return !s.lastCheckedAt || (dabar()-s.lastCheckedAt)>30*60*1000;
+    if(filtras===FiltravimoRezimai.UZDELTAS) return isOverdue(s.lastCheckedAt);
     return true;
   };
   const updateLova=(lova,fn,msg)=>{setStatusMap(prev=>{const old=prev[lova]||NUMATYTA_BUSENA;const next={...fn(old),lastBy:'Anon',lastAt:dabar()};setSnack({bed:lova,prev:old,msg});return{...prev,[lova]:next};});pushZurnalas(msg);};

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -4,7 +4,7 @@ import { Droppable, Draggable } from 'react-beautiful-dnd';
 import { Card, CardHeader, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Toilet, Brush, Check, ChevronDown, ChevronRight } from 'lucide-react';
-import { NUMATYTA_BUSENA, dabar, laikasFormatu } from '@/src/utils/bedState.js';
+import { NUMATYTA_BUSENA, laikasFormatu, isOverdue } from '@/src/utils/bedState.js';
 
 function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
   const s = status || NUMATYTA_BUSENA;
@@ -13,7 +13,7 @@ function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
     onSwipedRight: () => onClean(lova),
     delta: 50,
   });
-  const pradelsta = s.lastCheckedAt ? (dabar() - s.lastCheckedAt) > 30*60*1000 : true;
+  const pradelsta = isOverdue(s.lastCheckedAt);
   // Color legend:
   // - Blue: IT beds
   // - Red: overdue check

--- a/src/utils/bedState.js
+++ b/src/utils/bedState.js
@@ -18,4 +18,7 @@ export const laikasFormatu = t => {
   return `${m}:${String(s).padStart(2,'0')}`;
 };
 
-export default { NUMATYTA_BUSENA, dabar, laikasFormatu };
+export const isOverdue = (lastCheckedAt, limitMs = 30 * 60 * 1000) => {
+  return !lastCheckedAt || (dabar() - lastCheckedAt) > limitMs;
+};
+export default { NUMATYTA_BUSENA, dabar, laikasFormatu, isOverdue };


### PR DESCRIPTION
## Summary
- add `isOverdue` helper for bed lastCheckedAt handling
- use `isOverdue` in filters and zone card overdue logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b99249e95883209c9d6b7f3bceaec2