### PR TITLE
Add bed reset function and UI action

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -6,7 +6,7 @@ import useLocalStorageState from './hooks/useLocalStorageState.js';
 import Filters from './components/Filters.jsx';
 import Tabs from './components/Tabs.jsx';
 import ZoneSection from './components/ZoneSection.jsx';
-import { NUMATYTA_BUSENA, dabar, isOverdue } from '@/src/utils/bedState.js';
+import { NUMATYTA_BUSENA, dabar, isOverdue, resetBedStatus } from '@/src/utils/bedState.js';
 
 // ---------------- Konfigūracija -----------------
 const ZONOS = {
@@ -58,6 +58,7 @@ export default function LovuValdymoPrograma() {
   const toggleWC=b=>updateLova(b,s=>({...s,needsWC:!s.needsWC,lastWCAt:dabar(),flaggedAt:!s.needsWC?dabar():s.needsCleaning?s.flaggedAt:null}),`${b}: Tualetas`);
   const toggleCleaning=b=>updateLova(b,s=>({...s,needsCleaning:!s.needsCleaning,lastCleanAt:dabar(),flaggedAt:!s.needsCleaning?dabar():s.needsWC?s.flaggedAt:null}),`${b}: Valymas`);
   const markChecked=b=>updateLova(b,s=>({...s,lastCheckedAt:dabar()}),`${b}: Patikrinta`);
+  const resetLova=b=>{setStatusMap(prev=>{const old=prev[b]||NUMATYTA_BUSENA;const next=resetBedStatus();setSnack({bed:b,prev:old,msg:`${b}: Atstatyta`});return{...prev,[b]:next};});pushZurnalas(`${b}: Atstatyta`);};
   const checkAll=z=>{const lovos=zonosLovos[z]||[];setStatusMap(prev=>{const upd={...prev};lovos.forEach(l=>{upd[l]={...upd[l],lastCheckedAt:dabar()}});return upd});pushZurnalas(`Zona ${z} patikrinta`);};
   const undo=()=>{if(!snack)return;setStatusMap(p=>({...p,[snack.bed]:snack.prev}));setSnack(null);pushZurnalas(`Anuliuota ${snack.bed}`);};
   const handleZone=(z,user)=>{setZonuPadejejas(prev=>{const next={...prev,[z]:user};pushZurnalas(`Padėjėjas ${user||'nėra'} ${z}`);return next;});const lovos=zonosLovos[z]||[];setStatusMap(prev=>{const upd={...prev};lovos.forEach(l=>{upd[l]={...upd[l],lastCheckedAt:dabar()}});return upd});};
@@ -83,6 +84,7 @@ export default function LovuValdymoPrograma() {
                 onWC={toggleWC}
                 onClean={toggleCleaning}
                 onCheck={markChecked}
+                onReset={resetLova}
                 padejejas={zonuPadejejas[zona]}
                 onPadejejasChange={user=>handleZone(zona,user)}
                 checkAll={()=>checkAll(zona)}

--- a/__tests__/LovuValdymoPrograma.test.jsx
+++ b/__tests__/LovuValdymoPrograma.test.jsx
@@ -84,4 +84,20 @@ describe('LovuValdymoPrograma', () => {
     expect(within(zone2).getByText(/^1$/)).toBeInTheDocument();
     expect(within(zone1).queryByText(/^1$/)).toBeNull();
   });
+
+  test('reset button clears bed status', () => {
+    render(<LovuValdymoPrograma />);
+
+    const bed1Label = screen.getByText(/^1$/);
+    const card = bed1Label.parentElement.parentElement;
+    const buttons = within(card).getAllByRole('button');
+    const wcButton = buttons[0];
+    const resetButton = buttons[3];
+
+    fireEvent.click(wcButton);
+    fireEvent.click(resetButton);
+    fireEvent.click(screen.getByText('Tualetas'));
+
+    expect(screen.queryByText(/^1$/)).not.toBeInTheDocument();
+  });
 });

--- a/__tests__/ZoneSection.test.jsx
+++ b/__tests__/ZoneSection.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, within } from '@testing-library/react';
 import { DragDropContext } from 'react-beautiful-dnd';
 import ZoneSection from '../components/ZoneSection.jsx';
 
@@ -11,7 +11,7 @@ jest.mock(
   { virtual: true }
 );
 
-const renderZone = () =>
+const renderZone = (props = {}) =>
   render(
     <DragDropContext onDragEnd={() => {}}>
       <ZoneSection
@@ -22,9 +22,11 @@ const renderZone = () =>
         onWC={() => {}}
         onClean={() => {}}
         onCheck={() => {}}
+        onReset={() => {}}
         padejejas=""
         onPadejejasChange={() => {}}
         checkAll={() => {}}
+        {...props}
       />
     </DragDropContext>
   );
@@ -44,6 +46,19 @@ describe('ZoneSection responsiveness', () => {
     renderZone();
     const card = screen.getByText('1').closest('.bg-red-100');
     expect(card).toHaveClass('w-full', 'min-h-28', 'sm:min-h-32', 'h-auto');
+  });
+});
+
+describe('ZoneSection reset button', () => {
+  afterEach(() => cleanup());
+
+  test('invokes onReset when clicked', () => {
+    const onReset = jest.fn();
+    renderZone({ onReset });
+    const card = screen.getByText('1').parentElement.parentElement;
+    const resetBtn = within(card).getAllByRole('button')[3];
+    fireEvent.click(resetBtn);
+    expect(onReset).toHaveBeenCalledWith('1');
   });
 });
 

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -3,10 +3,10 @@ import { useSwipeable } from 'react-swipeable';
 import { Droppable, Draggable } from 'react-beautiful-dnd';
 import { Card, CardHeader, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Toilet, Brush, Check, ChevronDown, ChevronRight } from 'lucide-react';
+import { Toilet, Brush, Check, ChevronDown, ChevronRight, RotateCcw } from 'lucide-react';
 import { NUMATYTA_BUSENA, laikasFormatu, isOverdue } from '@/src/utils/bedState.js';
 
-function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
+function LovosKortele({ lova, index, status, onWC, onClean, onCheck, onReset }) {
   const s = status || NUMATYTA_BUSENA;
   const gesture = useSwipeable({
     onSwipedLeft: () => onWC(lova),
@@ -86,6 +86,17 @@ function LovosKortele({ lova, index, status, onWC, onClean, onCheck }) {
             >
               <Check size={20}/>
             </Button>
+            <Button
+              size="icon-sm"
+              variant="outline"
+              aria-label="Reset status"
+              onClick={e => {
+                e.stopPropagation();
+                onReset(lova);
+              }}
+            >
+              <RotateCcw size={20}/>
+            </Button>
           </CardFooter>
         </Card>
       )}
@@ -101,6 +112,7 @@ export default function ZoneSection({
   onWC,
   onClean,
   onCheck,
+  onReset,
   padejejas,
   onPadejejasChange,
   checkAll,
@@ -153,6 +165,7 @@ export default function ZoneSection({
                   onWC={onWC}
                   onClean={onClean}
                   onCheck={onCheck}
+                  onReset={onReset}
                 />
               ))}
               {provided.placeholder}

--- a/src/utils/bedState.js
+++ b/src/utils/bedState.js
@@ -9,6 +9,8 @@ export const NUMATYTA_BUSENA = {
   lastCleanAt: null,
 };
 
+export const resetBedStatus = () => ({ ...NUMATYTA_BUSENA });
+
 export const dabar = () => Date.now();
 
 export const laikasFormatu = t => {
@@ -21,4 +23,4 @@ export const laikasFormatu = t => {
 export const isOverdue = (lastCheckedAt, limitMs = 30 * 60 * 1000) => {
   return !lastCheckedAt || (dabar() - lastCheckedAt) > limitMs;
 };
-export default { NUMATYTA_BUSENA, dabar, laikasFormatu, isOverdue };
+export default { NUMATYTA_BUSENA, dabar, laikasFormatu, isOverdue, resetBedStatus };


### PR DESCRIPTION
## Summary
- add `resetBedStatus` helper to return a fresh bed state
- wire new `resetLova` action into program and zone section
- expose reset button on each bed card and test it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9935e228883208db43363e4c30b6b