### PR TITLE
feat: add useInterval hook

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -3,6 +3,7 @@ import { DragDropContext } from 'react-beautiful-dnd';
 import { Button } from '@/components/ui/button';
 import Pranesimas from './Pranesimas.jsx';
 import useLocalStorageState from './hooks/useLocalStorageState.js';
+import useInterval from './hooks/useInterval.js';
 import Filters from './components/Filters.jsx';
 import Tabs from './components/Tabs.jsx';
 import ZoneSection from './components/ZoneSection.jsx';
@@ -43,8 +44,8 @@ export default function LovuValdymoPrograma() {
   const [dark,setDark]=useState(false);
 
   useEffect(()=>{document.documentElement.classList.toggle('dark',dark);},[dark]);
-  
-  useEffect(()=>{const id=setInterval(()=>tick(x=>x+1),1000);return()=>clearInterval(id)},[]);
+
+  useInterval(() => tick(x => x + 1), 1000);
 
   const pushZurnalas=tekst=>setZurnalas(l=>[...l,{ts:dabar(),vartotojas:'Anon',tekstas:tekst}].slice(-200));
   const applyFilter=lov=>{

--- a/__tests__/useInterval.test.js
+++ b/__tests__/useInterval.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import useInterval from '../hooks/useInterval.js';
+
+function TestComponent({ callback, delay }) {
+  useInterval(callback, delay);
+  return null;
+}
+
+jest.useFakeTimers();
+
+test('sets interval and clears on unmount', () => {
+  const callback = jest.fn();
+  const { unmount } = render(<TestComponent callback={callback} delay={1000} />);
+
+  act(() => {
+    jest.advanceTimersByTime(3000);
+  });
+  expect(callback).toHaveBeenCalledTimes(3);
+
+  unmount();
+  act(() => {
+    jest.advanceTimersByTime(3000);
+  });
+  expect(callback).toHaveBeenCalledTimes(3);
+});
+
+test('updates interval when delay changes', () => {
+  const callback = jest.fn();
+  const { rerender } = render(<TestComponent callback={callback} delay={1000} />);
+
+  act(() => {
+    jest.advanceTimersByTime(1000);
+  });
+  expect(callback).toHaveBeenCalledTimes(1);
+
+  rerender(<TestComponent callback={callback} delay={500} />);
+  act(() => {
+    jest.advanceTimersByTime(500);
+  });
+  expect(callback).toHaveBeenCalledTimes(2);
+
+  act(() => {
+    jest.advanceTimersByTime(500);
+  });
+  expect(callback).toHaveBeenCalledTimes(3);
+});

--- a/hooks/useInterval.js
+++ b/hooks/useInterval.js
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react';
+
+export default function useInterval(callback, delay) {
+  const savedCallback = useRef();
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    if (delay == null) return;
+    const id = setInterval(() => savedCallback.current(), delay);
+    return () => clearInterval(id);
+  }, [delay]);
+}


### PR DESCRIPTION
## Summary
- implement reusable `useInterval` hook
- use `useInterval` in `LovuValdymoPrograma` instead of manual `setInterval`
- add tests covering hook interval setup and cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b994be3aa083208fef13e2066d5d13