### PR TITLE
Extract CSV export helper and add unit test

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -8,6 +8,7 @@ import Filters from './components/Filters.jsx';
 import Tabs from './components/Tabs.jsx';
 import ZoneSection from './components/ZoneSection.jsx';
 import { NUMATYTA_BUSENA, dabar, isOverdue, resetBedStatus } from '@/src/utils/bedState.js';
+import { exportLogToCsv } from '@/src/utils/exportCsv.js';
 
 // ---------------- Konfigūracija -----------------
 const ZONOS = {
@@ -65,7 +66,6 @@ export default function LovuValdymoPrograma() {
   const handleZone=(z,user)=>{setZonuPadejejas(prev=>{const next={...prev,[z]:user};pushZurnalas(`Padėjėjas ${user||'nėra'} ${z}`);return next;});const lovos=zonosLovos[z]||[];setStatusMap(prev=>{const upd={...prev};lovos.forEach(l=>{upd[l]={...upd[l],lastCheckedAt:dabar()}});return upd});};
   const onDragEnd=res=>{if(!res.destination)return;const {source,destination,draggableId}=res;setZonosLovos(prev=>{const result={...prev};const src=Array.from(result[source.droppableId]);const [moved]=src.splice(source.index,1);if(source.droppableId===destination.droppableId){src.splice(destination.index,0,moved);result[source.droppableId]=src;}else{const dest=Array.from(result[destination.droppableId]);dest.splice(destination.index,0,moved);result[source.droppableId]=src;result[destination.droppableId]=dest;}return result;});pushZurnalas(`Perkelta ${draggableId} į ${destination.droppableId}`);};
   const filteredLog=zurnalas.slice().reverse().filter(e=>e.tekstas.toLowerCase().includes(paieska.toLowerCase()));
-  const exportCsv=()=>{const hd='laikas,vartotojas,tekstas';const rows=filteredLog.map(e=>[new Date(e.ts).toISOString(),e.vartotojas,`"${e.tekstas.replace(/"/g,'""')}"`].join(','));const csv=[hd,...rows].join('\n');const blob=new Blob([csv],{type:'text/csv'});const url=URL.createObjectURL(blob);const a=document.createElement('a');a.href=url;a.download=`lovu_zurnalas_${new Date().toISOString()}.csv`;a.click();URL.revokeObjectURL(url);};
 
   return(
     <div className="mx-auto max-w-screen-xl">
@@ -96,7 +96,7 @@ export default function LovuValdymoPrograma() {
           <div>
             <div className="flex items-center gap-2 mb-1">
               <input className="border p-1 rounded text-xs flex-1 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100" placeholder="Ieškoti žurnale" value={paieska} onChange={e=>setPaieska(e.target.value)}/>
-              <Button size="sm" onClick={exportCsv}>Eksportuoti CSV</Button>
+              <Button size="sm" onClick={() => exportLogToCsv(filteredLog)}>Eksportuoti CSV</Button>
             </div>
             <ul className="text-xs space-y-1 max-h-[70vh] overflow-auto">
               {filteredLog.map((e,i)=><li key={i} className="py-0.5">{e.vartotojas}[{new Date(e.ts).toLocaleTimeString()}]: {e.tekstas}</li>)}

--- a/__tests__/exportCsv.test.js
+++ b/__tests__/exportCsv.test.js
@@ -1,0 +1,44 @@
+import { exportLogToCsv } from '../src/utils/exportCsv.js';
+
+describe('exportLogToCsv', () => {
+  const originalCreate = global.URL.createObjectURL;
+  const originalRevoke = global.URL.revokeObjectURL;
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-02T03:04:05.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    global.URL.createObjectURL = originalCreate;
+    global.URL.revokeObjectURL = originalRevoke;
+  });
+
+  test('generates CSV content and filename', async () => {
+    const createObjectURL = jest.fn(() => 'blob:url');
+    const revokeObjectURL = jest.fn();
+    global.URL.createObjectURL = createObjectURL;
+    global.URL.revokeObjectURL = revokeObjectURL;
+    const anchor = { click: jest.fn(), set href(v){this._href=v;}, get href(){return this._href;}, set download(v){this._download=v;}, get download(){return this._download;} };
+    jest.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    class BlobMock {
+      constructor(parts, opts){ this.parts = parts; this.options = opts; }
+    }
+    const OriginalBlob = global.Blob;
+    global.Blob = BlobMock;
+
+    const log = [{ ts: Date.parse('2024-01-01T00:00:00.000Z'), vartotojas: 'User', tekstas: 'Hello "world"' }];
+    exportLogToCsv(log);
+
+    const blob = createObjectURL.mock.calls[0][0];
+    const text = blob.parts[0];
+    expect(text).toBe('laikas,vartotojas,tekstas\n2024-01-01T00:00:00.000Z,User,"Hello ""world"""');
+    expect(anchor.download).toBe('lovu_zurnalas_2024-01-02T03:04:05.000Z.csv');
+    expect(anchor.click).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:url');
+
+    global.Blob = OriginalBlob;
+  });
+});

--- a/src/utils/exportCsv.js
+++ b/src/utils/exportCsv.js
@@ -1,0 +1,16 @@
+export function exportLogToCsv(logEntries) {
+  const header = 'laikas,vartotojas,tekstas';
+  const rows = logEntries.map(entry => {
+    const escapedText = `"${entry.tekstas.replace(/"/g, '""')}"`;
+    return [new Date(entry.ts).toISOString(), entry.vartotojas, escapedText].join(',');
+  });
+  const csv = [header, ...rows].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `lovu_zurnalas_${new Date().toISOString()}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+export default { exportLogToCsv };


### PR DESCRIPTION
## Summary
- move CSV export logic into reusable `exportLogToCsv` utility
- use `exportLogToCsv` in `LovuValdymoPrograma` for CSV downloads
- add unit tests verifying CSV content and filename

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b99a4ebab483208955b4c02cbe4ee2