### PR TITLE
feat: extract log filtering utility

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -9,6 +9,7 @@ import Tabs from './components/Tabs.jsx';
 import ZoneSection from './components/ZoneSection.jsx';
 import { NUMATYTA_BUSENA, dabar, isOverdue, resetBedStatus } from '@/src/utils/bedState.js';
 import { exportLogToCsv } from '@/src/utils/exportCsv.js';
+import { filterLogEntries } from '@/src/utils/logFilter.js';
 
 // ---------------- Konfigūracija -----------------
 const ZONOS = {
@@ -65,7 +66,7 @@ export default function LovuValdymoPrograma() {
   const undo=()=>{if(!snack)return;setStatusMap(p=>({...p,[snack.bed]:snack.prev}));setSnack(null);pushZurnalas(`Anuliuota ${snack.bed}`);};
   const handleZone=(z,user)=>{setZonuPadejejas(prev=>{const next={...prev,[z]:user};pushZurnalas(`Padėjėjas ${user||'nėra'} ${z}`);return next;});const lovos=zonosLovos[z]||[];setStatusMap(prev=>{const upd={...prev};lovos.forEach(l=>{upd[l]={...upd[l],lastCheckedAt:dabar()}});return upd});};
   const onDragEnd=res=>{if(!res.destination)return;const {source,destination,draggableId}=res;setZonosLovos(prev=>{const result={...prev};const src=Array.from(result[source.droppableId]);const [moved]=src.splice(source.index,1);if(source.droppableId===destination.droppableId){src.splice(destination.index,0,moved);result[source.droppableId]=src;}else{const dest=Array.from(result[destination.droppableId]);dest.splice(destination.index,0,moved);result[source.droppableId]=src;result[destination.droppableId]=dest;}return result;});pushZurnalas(`Perkelta ${draggableId} į ${destination.droppableId}`);};
-  const filteredLog=zurnalas.slice().reverse().filter(e=>e.tekstas.toLowerCase().includes(paieska.toLowerCase()));
+  const filteredLog = filterLogEntries(zurnalas, paieska);
 
   return(
     <div className="mx-auto max-w-screen-xl">

--- a/__tests__/logFilter.test.js
+++ b/__tests__/logFilter.test.js
@@ -1,0 +1,29 @@
+import { filterLogEntries } from '../src/utils/logFilter.js';
+
+describe('filterLogEntries', () => {
+  test('filters entries case-insensitively', () => {
+    const log = [
+      { tekstas: 'Error occurred' },
+      { tekstas: 'All good' },
+      { tekstas: 'another ERROR here' },
+    ];
+    const result = filterLogEntries(log, 'error');
+    expect(result).toEqual([
+      { tekstas: 'another ERROR here' },
+      { tekstas: 'Error occurred' },
+    ]);
+  });
+
+  test('returns entries in reverse order', () => {
+    const log = [
+      { tekstas: 'first match' },
+      { tekstas: 'unrelated' },
+      { tekstas: 'second match' },
+    ];
+    const result = filterLogEntries(log, 'match');
+    expect(result).toEqual([
+      { tekstas: 'second match' },
+      { tekstas: 'first match' },
+    ]);
+  });
+});

--- a/src/utils/logFilter.js
+++ b/src/utils/logFilter.js
@@ -1,0 +1,6 @@
+export function filterLogEntries(log, searchTerm) {
+  const term = searchTerm.toLowerCase();
+  return log.slice().reverse().filter(entry => entry.tekstas.toLowerCase().includes(term));
+}
+
+export default { filterLogEntries };


### PR DESCRIPTION
## Summary
- add `filterLogEntries` utility to reverse and search logs
- use helper in main dashboard instead of inline filter
- test that log filtering is case-insensitive and preserves reverse order

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b99b7be8388320a84c2c70cb4c91b5