### PR TITLE
docs: add usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,26 @@ A simple React program for managing hospital bed assignments. The main component
    npm run build
    ```
 
+## Usage
+
+### Toggling Filters
+Use the filter buttons above the zones to show all beds or only those needing attention for toilets, cleaning, or overdue checks.
+Example:
+1. Click **Tualetas** to show beds awaiting the toilet.
+2. Press <kbd>Tab</kbd> to focus a filter button and <kbd>Enter</kbd> to activate it.
+
+### Moving Beds Between Zones
+Drag a bed card to a different zone to reassign it.
+Example: drag bed **IT-01** from *Zone A* to *Zone B*.
+Keyboard: press <kbd>Space</kbd> on a focused bed to start moving, use arrow keys to choose a zone, then press <kbd>Space</kbd> again to drop.
+
+### Exporting Logs
+The activity log in the right pane can be downloaded for auditing.
+Example: after filtering the log, click **Eksportuoti CSV** to save `lovu_zurnalas_YYYY-MM-DD.csv`.
+
+### Dark Mode Toggle
+A button in the header switches between light and dark themes.
+Example: click **Dark** to enable the darker palette; click again to return to light mode.
+Accessibility: the toggle button is focusable via keyboard and preserves contrast for better readability.
+
+


### PR DESCRIPTION
## Summary
- document filters, bed movement, log export, and dark mode in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a78df5e083209cc40d646c335f89