### PR TITLE
Add bed status summary component

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -8,6 +8,7 @@ import Filters from './components/Filters.jsx';
 import Tabs from './components/Tabs.jsx';
 import ZoneSection from './components/ZoneSection.jsx';
 import Header from './components/Header.jsx';
+import StatusSummary from './components/StatusSummary.jsx';
 import { NUMATYTA_BUSENA, dabar, isOverdue, resetBedStatus } from '@/src/utils/bedState.js';
 import { exportLogToCsv } from '@/src/utils/exportCsv.js';
 import { filterLogEntries } from '@/src/utils/logFilter.js';
@@ -75,7 +76,8 @@ export default function LovuValdymoPrograma() {
       <main className="max-w-screen-xl mx-auto p-2">
         <Filters filtras={filtras} setFiltras={setFiltras} FiltravimoRezimai={FiltravimoRezimai}/>
         <Tabs skirtukas={skirtukas} setSkirtukas={setSkirtukas}/>
-        {skirtukas==='lovos'?(
+        {skirtukas==='lovos' && <StatusSummary statusMap={statusMap}/>} 
+        {skirtukas==='lovos'?( 
           <DragDropContext onDragEnd={onDragEnd}>
             {Object.entries(zonosLovos).map(([zona,lovos])=> (
               <ZoneSection

--- a/__tests__/LovuValdymoPrograma.test.jsx
+++ b/__tests__/LovuValdymoPrograma.test.jsx
@@ -22,33 +22,35 @@ describe('LovuValdymoPrograma', () => {
   test('filters beds by toilet status', () => {
     render(<LovuValdymoPrograma />);
 
-    const bed1Label = screen.getByText(/^1$/);
+    const zone = screen.getByText('Zona 1').parentElement.parentElement;
+    const bed1Label = within(zone).getByText(/^1$/);
     const card = bed1Label.parentElement.parentElement;
     const wcButton = within(card).getAllByRole('button')[0];
     fireEvent.click(wcButton);
 
     fireEvent.click(screen.getByText('Tualetas'));
 
-    expect(screen.getByText(/^1$/)).toBeInTheDocument();
-    expect(screen.queryByText(/^2$/)).not.toBeInTheDocument();
+    expect(within(zone).getByText(/^1$/)).toBeInTheDocument();
+    expect(within(zone).queryByText(/^2$/)).not.toBeInTheDocument();
   });
 
   test('undo reverses status change', () => {
     render(<LovuValdymoPrograma />);
 
-    const bed1Label = screen.getByText(/^1$/);
+    const zone = screen.getByText('Zona 1').parentElement.parentElement;
+    const bed1Label = within(zone).getByText(/^1$/);
     const card = bed1Label.parentElement.parentElement;
     const wcButton = within(card).getAllByRole('button')[0];
     fireEvent.click(wcButton);
 
     fireEvent.click(screen.getByText('Tualetas'));
-    expect(screen.getByText(/^1$/)).toBeInTheDocument();
+    expect(within(zone).getByText(/^1$/)).toBeInTheDocument();
 
     const msg = screen.getByText('1: Tualetas');
     const undoBtn = within(msg).getByRole('button');
     fireEvent.click(undoBtn);
 
-    expect(screen.queryByText(/^1$/)).not.toBeInTheDocument();
+    expect(within(zone).queryByText(/^1$/)).not.toBeInTheDocument();
   });
 
   test('zone helper update marks beds checked', () => {
@@ -60,7 +62,8 @@ describe('LovuValdymoPrograma', () => {
 
     expect(input.value).toBe('Jonas');
 
-    const bed1Label = screen.getByText(/^1$/);
+    const zone = screen.getByText('Zona 1').parentElement.parentElement;
+    const bed1Label = within(zone).getByText(/^1$/);
     const card = bed1Label.parentElement.parentElement;
     expect(within(card).getByText(/Patikrinta/)).toBeInTheDocument();
   });
@@ -88,7 +91,8 @@ describe('LovuValdymoPrograma', () => {
   test('reset button clears bed status', () => {
     render(<LovuValdymoPrograma />);
 
-    const bed1Label = screen.getByText(/^1$/);
+    const zone = screen.getByText('Zona 1').parentElement.parentElement;
+    const bed1Label = within(zone).getByText(/^1$/);
     const card = bed1Label.parentElement.parentElement;
     const buttons = within(card).getAllByRole('button');
     const wcButton = buttons[0];
@@ -98,6 +102,6 @@ describe('LovuValdymoPrograma', () => {
     fireEvent.click(resetButton);
     fireEvent.click(screen.getByText('Tualetas'));
 
-    expect(screen.queryByText(/^1$/)).not.toBeInTheDocument();
+    expect(within(zone).queryByText(/^1$/)).not.toBeInTheDocument();
   });
 });

--- a/__tests__/StatusSummary.test.jsx
+++ b/__tests__/StatusSummary.test.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import StatusSummary from '../components/StatusSummary.jsx';
+
+describe('StatusSummary', () => {
+  test('updates counts when bed statuses change', () => {
+    const { rerender } = render(<StatusSummary statusMap={{}} />);
+    expect(screen.getByLabelText('needs-wc')).toHaveTextContent('0');
+    expect(screen.getByLabelText('needs-cleaning')).toHaveTextContent('0');
+    expect(screen.getByLabelText('overdue')).toHaveTextContent('0');
+
+    rerender(
+      <StatusSummary
+        statusMap={{
+          A: { needsWC: true, needsCleaning: true, lastCheckedAt: 0 },
+        }}
+      />
+    );
+    expect(screen.getByLabelText('needs-wc')).toHaveTextContent('1');
+    expect(screen.getByLabelText('needs-cleaning')).toHaveTextContent('1');
+    expect(screen.getByLabelText('overdue')).toHaveTextContent('1');
+
+    rerender(
+      <StatusSummary
+        statusMap={{
+          A: { needsWC: false, needsCleaning: false, lastCheckedAt: Date.now() },
+        }}
+      />
+    );
+    expect(screen.getByLabelText('needs-wc')).toHaveTextContent('0');
+    expect(screen.getByLabelText('needs-cleaning')).toHaveTextContent('0');
+    expect(screen.getByLabelText('overdue')).toHaveTextContent('0');
+  });
+});

--- a/components/StatusSummary.jsx
+++ b/components/StatusSummary.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Card } from '@/components/ui/card';
+import { Toilet, Brush, Clock } from 'lucide-react';
+import { isOverdue } from '@/src/utils/bedState.js';
+
+export default function StatusSummary({ statusMap }) {
+  const statuses = Object.values(statusMap || {});
+  const wcCount = statuses.filter(s => s?.needsWC).length;
+  const cleaningCount = statuses.filter(s => s?.needsCleaning).length;
+  const overdueCount = statuses.filter(s => isOverdue(s?.lastCheckedAt)).length;
+
+  return (
+    <div className="grid grid-cols-3 gap-2 my-2">
+      <Card aria-label="needs-wc" className="flex items-center justify-center gap-2 p-2 text-sm">
+        <Toilet className="text-blue-600" />
+        <span>{wcCount}</span>
+      </Card>
+      <Card aria-label="needs-cleaning" className="flex items-center justify-center gap-2 p-2 text-sm">
+        <Brush className="text-green-600" />
+        <span>{cleaningCount}</span>
+      </Card>
+      <Card aria-label="overdue" className="flex items-center justify-center gap-2 p-2 text-sm">
+        <Clock className="text-red-600" />
+        <span>{overdueCount}</span>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add StatusSummary component to show counts for beds needing WC, cleaning, and overdue checks
- integrate StatusSummary into main program when the "lovos" tab is active
- cover StatusSummary with unit tests and adjust existing tests for new UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a8c1907c83209f603a42c5a0ab05