### PR TITLE
Handle undefined search term in log filter

### DIFF
--- a/__tests__/logFilter.test.js
+++ b/__tests__/logFilter.test.js
@@ -52,4 +52,17 @@ describe('filterLogEntries', () => {
       { tekstas: 'new', vartotojas: 'User2', ts: ts2023 },
     ]);
   });
+
+  test('handles undefined search term without errors', () => {
+    const log = [
+      { tekstas: 'first', vartotojas: 'User1', ts: 1 },
+      { tekstas: 'second', vartotojas: 'User2', ts: 2 },
+    ];
+    expect(() => filterLogEntries(log, undefined)).not.toThrow();
+    const result = filterLogEntries(log, undefined);
+    expect(result).toEqual([
+      { tekstas: 'second', vartotojas: 'User2', ts: 2 },
+      { tekstas: 'first', vartotojas: 'User1', ts: 1 },
+    ]);
+  });
 });

--- a/src/utils/logFilter.js
+++ b/src/utils/logFilter.js
@@ -1,5 +1,5 @@
 export function filterLogEntries(log, searchTerm) {
-  const term = searchTerm.toLowerCase();
+  const term = (searchTerm || '').toLowerCase();
   return log
     .slice()
     .reverse()


### PR DESCRIPTION
## Summary
- Default `searchTerm` to an empty string before lowercasing in `filterLogEntries`
- Add unit test ensuring `filterLogEntries` handles undefined search term without errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d88176908320bf9dbc79e6f3d93e