### PR TITLE
Use label placeholder in Filters test descriptions

### DIFF
--- a/__tests__/Filters.test.jsx
+++ b/__tests__/Filters.test.jsx
@@ -17,7 +17,7 @@ const options = [
 ];
 
 describe('Filters', () => {
-  test.each(options)('%s button sets filter and variant', ({ label, value, activeClass }) => {
+  test.each(options)('$label button sets filter and variant', ({ label, value, activeClass }) => {
     const setFiltras = jest.fn();
     const { rerender } = render(
       <Filters filtras={FiltravimoRezimai.VISI} setFiltras={setFiltras} FiltravimoRezimai={FiltravimoRezimai} />


### PR DESCRIPTION
## Summary
- use `$label` placeholder for parameterized Filters tests so titles show button names

## Testing
- `npm test __tests__/Filters.test.jsx -- --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68b9d92bd7488320940afaed9d1f74cd