### PR TITLE
Handle beds without checks as not overdue

### DIFF
--- a/__tests__/StatusSummary.test.jsx
+++ b/__tests__/StatusSummary.test.jsx
@@ -12,6 +12,15 @@ describe('StatusSummary', () => {
     rerender(
       <StatusSummary
         statusMap={{
+          A: { needsWC: false, needsCleaning: false, lastCheckedAt: null },
+        }}
+      />
+    );
+    expect(screen.getByLabelText('overdue')).toHaveTextContent('0');
+
+    rerender(
+      <StatusSummary
+        statusMap={{
           A: { needsWC: true, needsCleaning: true, lastCheckedAt: 0 },
         }}
       />

--- a/__tests__/ZoneSection.test.jsx
+++ b/__tests__/ZoneSection.test.jsx
@@ -37,14 +37,14 @@ describe('ZoneSection responsiveness', () => {
   test('uses base size classes on small screens', () => {
     window.innerWidth = 500;
     renderZone();
-    const card = screen.getByText('1').closest('.bg-red-100');
+    const card = screen.getByText('1').closest('.bg-gray-200');
     expect(card).toHaveClass('w-full', 'min-h-24', 'h-auto');
   });
 
   test('includes larger size classes for sm breakpoint', () => {
     window.innerWidth = 700;
     renderZone();
-    const card = screen.getByText('1').closest('.bg-red-100');
+    const card = screen.getByText('1').closest('.bg-gray-200');
     expect(card).toHaveClass('w-full', 'min-h-24', 'sm:min-h-28', 'h-auto');
   });
 });
@@ -72,6 +72,22 @@ describe('ZoneSection collapse toggle', () => {
     expect(queryByText('1')).not.toBeInTheDocument();
     fireEvent.click(screen.getByLabelText('Expand zone'));
     expect(queryByText('1')).toBeInTheDocument();
+  });
+});
+
+describe('ZoneSection overdue animation', () => {
+  afterEach(() => cleanup());
+
+  test('beds without last check do not animate', () => {
+    renderZone();
+    const card = screen.getByText('1').closest('.bg-gray-200');
+    expect(card).not.toHaveClass('animate-pulse');
+  });
+
+  test('beds pulse after exceeding limit', () => {
+    renderZone({ statusMap: { '1': { lastCheckedAt: Date.now() - 31 * 60 * 1000 } } });
+    const card = screen.getByText('1').closest('.bg-red-100');
+    expect(card).toHaveClass('animate-pulse');
   });
 });
 

--- a/__tests__/isOverdue.test.js
+++ b/__tests__/isOverdue.test.js
@@ -1,0 +1,21 @@
+import { isOverdue } from '../src/utils/bedState.js';
+
+describe('isOverdue', () => {
+  test('returns false when lastCheckedAt is null', () => {
+    expect(isOverdue(null)).toBe(false);
+  });
+
+  test('treats zero timestamp as overdue', () => {
+    expect(isOverdue(0)).toBe(true);
+  });
+
+  test('returns false when within limit', () => {
+    const lastChecked = Date.now() - 10 * 60 * 1000; // 10 minutes ago
+    expect(isOverdue(lastChecked)).toBe(false);
+  });
+
+  test('returns true when beyond limit', () => {
+    const lastChecked = Date.now() - 31 * 60 * 1000; // 31 minutes ago
+    expect(isOverdue(lastChecked)).toBe(true);
+  });
+});

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -13,6 +13,7 @@ function LovosKortele({ lova, index, status, onWC, onClean, onCheck, onReset }) 
     onSwipedRight: () => onClean(lova),
     delta: 50,
   });
+  // Beds are overdue only when lastCheckedAt exists and exceeds the limit
   const pradelsta = isOverdue(s.lastCheckedAt);
   // Color legend:
   // - Blue: IT beds

--- a/src/utils/bedState.js
+++ b/src/utils/bedState.js
@@ -21,6 +21,6 @@ export const laikasFormatu = t => {
 };
 
 export const isOverdue = (lastCheckedAt, limitMs = 30 * 60 * 1000) => {
-  return !lastCheckedAt || (dabar() - lastCheckedAt) > limitMs;
+  return lastCheckedAt != null && (dabar() - lastCheckedAt) > limitMs;
 };
 export default { NUMATYTA_BUSENA, dabar, laikasFormatu, isOverdue, resetBedStatus };


### PR DESCRIPTION
## Summary
- update `isOverdue` to ignore null timestamps and only flag when limit exceeded
- clarify overdue logic in `ZoneSection` and add tests for pulsing behaviour
- extend status summary and introduce dedicated `isOverdue` tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bae0fd261c8320a1df372fb9f51da9