### PR TITLE
Expand main layout width

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -118,7 +118,7 @@ export default function LovuValdymoPrograma() {
         alertsMuted={alertsMuted}
         toggleMute={() => setAlertsMuted(m => !m)}
       />
-      <main className="max-w-screen-xl mx-auto p-2">
+      <main className="max-w-screen-2xl mx-auto p-2">
         <Filters filtras={filtras} setFiltras={setFiltras} FiltravimoRezimai={FiltravimoRezimai}/>
         <Tabs skirtukas={skirtukas} setSkirtukas={setSkirtukas}/>
         {skirtukas==='lovos' && <StatusSummary statusMap={statusMap}/>} 

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 export default function Header({ dark, toggleDark, alertsMuted, toggleMute }) {
   return (
     <header className="glass text-gray-900 dark:text-gray-100 mb-2">
-      <div className="max-w-screen-xl mx-auto px-4 py-2 flex items-center justify-between">
+      <div className="max-w-screen-2xl mx-auto px-4 py-2 flex items-center justify-between">
         <h1 className="text-lg font-semibold">ED Dashboard</h1>
         <div className="flex gap-2">
           <Button


### PR DESCRIPTION
## Summary
- widen dashboard container to `max-w-screen-2xl` for additional bed space
- adjust header width to align with wider layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbdcd354908320a6b889f404a9b813