### PR TITLE
Add zone navigation dropdown

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -45,6 +45,7 @@ export default function LovuValdymoPrograma() {
   const [dark,setDark]=useState(false);
   const [alertsMuted,setAlertsMuted]=useState(false);
   const alertedRef = useRef(new Set());
+  const zoneRefs = useRef({});
 
   useEffect(()=>{
     const lovos = Object.values(zonosLovos).flat();
@@ -108,6 +109,16 @@ export default function LovuValdymoPrograma() {
   const undo=()=>{if(!snack)return;setStatusMap(p=>({...p,[snack.bed]:snack.prev}));setSnack(null);pushZurnalas(`Anuliuota ${snack.bed}`);};
   const handleZone=(z,user)=>{setZonuPadejejas(prev=>{const next={...prev,[z]:user};pushZurnalas(`Padėjėjas ${user||'nėra'} ${z}`);return next;});const lovos=zonosLovos[z]||[];setStatusMap(prev=>{const upd={...prev};lovos.forEach(l=>{upd[l]={...upd[l],lastCheckedAt:dabar()}});return upd});};
   const onDragEnd=res=>{if(!res.destination)return;const {source,destination,draggableId}=res;setZonosLovos(prev=>{const result={...prev};const src=Array.from(result[source.droppableId]);const [moved]=src.splice(source.index,1);if(source.droppableId===destination.droppableId){src.splice(destination.index,0,moved);result[source.droppableId]=src;}else{const dest=Array.from(result[destination.droppableId]);dest.splice(destination.index,0,moved);result[source.droppableId]=src;result[destination.droppableId]=dest;}return result;});pushZurnalas(`Perkelta ${draggableId} į ${destination.droppableId}`);};
+  const scrollToZone = zona => {
+    const el = zoneRefs.current[zona];
+    if (el && el.scrollIntoView) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      el.classList.add('ring-2', 'ring-yellow-300');
+      setTimeout(() => {
+        el.classList.remove('ring-2', 'ring-yellow-300');
+      }, 1500);
+    }
+  };
   const filteredLog = filterLogEntries(zurnalas, paieska);
 
   return(
@@ -117,6 +128,8 @@ export default function LovuValdymoPrograma() {
         toggleDark={() => setDark(d => !d)}
         alertsMuted={alertsMuted}
         toggleMute={() => setAlertsMuted(m => !m)}
+        zones={Object.keys(zonosLovos)}
+        onSelectZone={scrollToZone}
       />
       <main className="max-w-screen-2xl mx-auto p-2">
         <Filters filtras={filtras} setFiltras={setFiltras} FiltravimoRezimai={FiltravimoRezimai}/>
@@ -126,6 +139,7 @@ export default function LovuValdymoPrograma() {
           <DragDropContext onDragEnd={onDragEnd}>
             {Object.entries(zonosLovos).map(([zona,lovos])=> (
               <ZoneSection
+                ref={el => (zoneRefs.current[zona] = el)}
                 key={zona}
                 zona={zona}
                 lovos={lovos}

--- a/__tests__/LovuValdymoPrograma.test.jsx
+++ b/__tests__/LovuValdymoPrograma.test.jsx
@@ -22,7 +22,7 @@ describe('LovuValdymoPrograma', () => {
   test('filters beds by toilet status', () => {
     render(<LovuValdymoPrograma />);
 
-    const zone = screen.getByText('A zona').parentElement.parentElement;
+    const zone = screen.getByRole('heading', { name: 'A zona' }).parentElement.parentElement;
     const bed1Label = within(zone).getByText(/^1$/);
     const card = bed1Label.parentElement.parentElement;
     const wcButton = within(card).getAllByRole('button')[0];
@@ -37,7 +37,7 @@ describe('LovuValdymoPrograma', () => {
   test('undo reverses status change', () => {
     render(<LovuValdymoPrograma />);
 
-    const zone = screen.getByText('A zona').parentElement.parentElement;
+    const zone = screen.getByRole('heading', { name: 'A zona' }).parentElement.parentElement;
     const bed1Label = within(zone).getByText(/^1$/);
     const card = bed1Label.parentElement.parentElement;
     const wcButton = within(card).getAllByRole('button')[0];
@@ -56,13 +56,13 @@ describe('LovuValdymoPrograma', () => {
   test('zone helper update marks beds checked', () => {
     render(<LovuValdymoPrograma />);
 
-    const row = screen.getByText('A zona').parentElement;
+    const row = screen.getByRole('heading', { name: 'A zona' }).parentElement;
     const input = within(row).getByPlaceholderText('Padėjėjas');
     fireEvent.change(input, { target: { value: 'Jonas' } });
 
     expect(input.value).toBe('Jonas');
 
-    const zone = screen.getByText('A zona').parentElement.parentElement;
+    const zone = screen.getByRole('heading', { name: 'A zona' }).parentElement.parentElement;
     const bed1Label = within(zone).getByText(/^1$/);
     const card = bed1Label.parentElement.parentElement;
     expect(within(card).getByText(/Patikrinta/)).toBeInTheDocument();
@@ -72,10 +72,10 @@ describe('LovuValdymoPrograma', () => {
     render(<LovuValdymoPrograma />);
 
     expect(
-      within(screen.getByText('A zona').parentElement.parentElement).getByText(/^1$/)
+      within(screen.getByRole('heading', { name: 'A zona' }).parentElement.parentElement).getByText(/^1$/)
     ).toBeInTheDocument();
     expect(
-      within(screen.getByText('B zona').parentElement.parentElement).queryByText(/^1$/)
+      within(screen.getByRole('heading', { name: 'B zona' }).parentElement.parentElement).queryByText(/^1$/)
     ).toBeNull();
 
     act(() => {
@@ -86,8 +86,8 @@ describe('LovuValdymoPrograma', () => {
       });
     });
 
-    const zone1 = screen.getByText('A zona').parentElement.parentElement;
-    const zone2 = screen.getByText('B zona').parentElement.parentElement;
+    const zone1 = screen.getByRole('heading', { name: 'A zona' }).parentElement.parentElement;
+    const zone2 = screen.getByRole('heading', { name: 'B zona' }).parentElement.parentElement;
     expect(within(zone1).getByText(/^1$/)).toBeInTheDocument();
     expect(within(zone2).queryByText(/^1$/)).toBeNull();
   });
@@ -95,7 +95,7 @@ describe('LovuValdymoPrograma', () => {
   test('reset button clears bed status', () => {
     render(<LovuValdymoPrograma />);
 
-    const zone = screen.getByText('A zona').parentElement.parentElement;
+    const zone = screen.getByRole('heading', { name: 'A zona' }).parentElement.parentElement;
     const bed1Label = within(zone).getByText(/^1$/);
     const card = bed1Label.parentElement.parentElement;
     const buttons = within(card).getAllByRole('button');

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -1,12 +1,45 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 
-export default function Header({ dark, toggleDark, alertsMuted, toggleMute }) {
+export default function Header({
+  dark,
+  toggleDark,
+  alertsMuted,
+  toggleMute,
+  zones = [],
+  onSelectZone,
+}) {
+  const [selected, setSelected] = React.useState('');
+
+  const handleChange = e => {
+    const value = e.target.value;
+    if (value) {
+      onSelectZone && onSelectZone(value);
+      setSelected('');
+    }
+  };
+
   return (
     <header className="glass text-gray-900 dark:text-gray-100 mb-2">
       <div className="max-w-screen-2xl mx-auto px-4 py-2 flex items-center justify-between">
         <h1 className="text-lg font-semibold">ED Dashboard</h1>
-        <div className="flex gap-2">
+        <div className="flex gap-2 items-center">
+          {zones.length > 0 && (
+            <select
+              value={selected}
+              onChange={handleChange}
+              className="glass border rounded px-2 py-1 text-sm bg-white/60 dark:bg-gray-900/60 text-gray-900 dark:text-gray-100"
+            >
+              <option value="" disabled>
+                Zonos
+              </option>
+              {zones.map(z => (
+                <option key={z} value={z}>
+                  {z}
+                </option>
+              ))}
+            </select>
+          )}
           <Button
             size="sm"
             variant="outline"

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -105,7 +105,7 @@ function LovosKortele({ lova, index, status, onWC, onClean, onCheck, onReset }) 
   );
 }
 
-export default function ZoneSection({
+const ZoneSection = React.forwardRef(function ZoneSection({
   zona,
   lovos,
   statusMap,
@@ -117,11 +117,11 @@ export default function ZoneSection({
   padejejas,
   onPadejejasChange,
   checkAll,
-}) {
+}, ref) {
   const [expanded, setExpanded] = React.useState(true);
 
   return (
-    <div className="mb-2">
+    <div ref={ref} className="mb-2">
       <div className="flex items-center mb-1 gap-2">
         <Button
           size="icon"
@@ -176,4 +176,6 @@ export default function ZoneSection({
       )}
     </div>
   );
-}
+});
+
+export default ZoneSection;


### PR DESCRIPTION
## Summary
- add zone selection dropdown to header
- scroll and highlight zone sections using refs
- update tests for new header layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbece4658c8320be0f61c94921d3e2