### PR TITLE
Arrange navigation buttons in a single row on desktop

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -133,8 +133,19 @@ export default function LovuValdymoPrograma() {
         onSelectZone={scrollToZone}
       />
       <main className="max-w-screen-2xl mx-auto p-2">
-        <Filters filtras={filtras} setFiltras={setFiltras} FiltravimoRezimai={FiltravimoRezimai}/>
-        <Tabs skirtukas={skirtukas} setSkirtukas={setSkirtukas}/>
+        <nav className="flex flex-col md:flex-row gap-2 mb-1">
+          <Filters
+            filtras={filtras}
+            setFiltras={setFiltras}
+            FiltravimoRezimai={FiltravimoRezimai}
+            className="flex-1 md:flex-[4]"
+          />
+          <Tabs
+            skirtukas={skirtukas}
+            setSkirtukas={setSkirtukas}
+            className="flex-1 md:flex-[3]"
+          />
+        </nav>
         {skirtukas==='lovos' && <StatusSummary statusMap={statusMap}/>}
         {skirtukas==='lovos' ? (
           <DragDropContext onDragEnd={onDragEnd}>

--- a/components/Filters.jsx
+++ b/components/Filters.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 
-export default function Filters({ filtras, setFiltras, FiltravimoRezimai }) {
+export default function Filters({ filtras, setFiltras, FiltravimoRezimai, className = '' }) {
   return (
-    <div className="flex gap-2 mb-1">
+    <div className={`flex gap-2 ${className}`}>
       <Button
         className="flex-1 text-center"
         size="sm"

--- a/components/Tabs.jsx
+++ b/components/Tabs.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 
-export default function Tabs({ skirtukas, setSkirtukas }) {
+export default function Tabs({ skirtukas, setSkirtukas, className = '' }) {
   return (
-    <div className="flex gap-2 mb-1">
+    <div className={`flex gap-2 ${className}`}>
       <Button
         className="flex-1 text-center"
         size="sm"


### PR DESCRIPTION
## Summary
- Allow Filters and Tabs components to accept custom classes
- Group Filters and Tabs in a responsive nav so buttons sit on one line on desktop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc1595d0988320951ead9148f09ac3