### PR TITLE
Increase navigation button height

### DIFF
--- a/components/Filters.jsx
+++ b/components/Filters.jsx
@@ -6,7 +6,7 @@ export default function Filters({ filtras, setFiltras, FiltravimoRezimai, classN
     <div className={`flex gap-2 ${className}`}>
       <Button
         className="flex-1 text-center"
-        size="sm"
+        size="md"
         onClick={() => setFiltras(FiltravimoRezimai.VISI)}
         variant={filtras===FiltravimoRezimai.VISI?'default':'outline'}
       >
@@ -14,7 +14,7 @@ export default function Filters({ filtras, setFiltras, FiltravimoRezimai, classN
       </Button>
       <Button
         className="flex-1 text-center"
-        size="sm"
+        size="md"
         onClick={() => setFiltras(FiltravimoRezimai.TUALETAS)}
         variant={filtras===FiltravimoRezimai.TUALETAS?'default':'outline'}
       >
@@ -22,7 +22,7 @@ export default function Filters({ filtras, setFiltras, FiltravimoRezimai, classN
       </Button>
       <Button
         className="flex-1 text-center"
-        size="sm"
+        size="md"
         onClick={() => setFiltras(FiltravimoRezimai.VALYMAS)}
         variant={filtras===FiltravimoRezimai.VALYMAS?'default':'outline'}
       >
@@ -30,7 +30,7 @@ export default function Filters({ filtras, setFiltras, FiltravimoRezimai, classN
       </Button>
       <Button
         className="flex-1 text-center"
-        size="sm"
+        size="md"
         onClick={() => setFiltras(FiltravimoRezimai.UZDELTAS)}
         variant={filtras===FiltravimoRezimai.UZDELTAS?'warning':'outline'}
       >

--- a/components/Tabs.jsx
+++ b/components/Tabs.jsx
@@ -6,7 +6,7 @@ export default function Tabs({ skirtukas, setSkirtukas, className = '' }) {
     <div className={`flex gap-2 ${className}`}>
       <Button
         className="flex-1 text-center"
-        size="sm"
+        size="md"
         onClick={() => setSkirtukas('lovos')}
         variant={skirtukas==='lovos'?'default':'outline'}
       >
@@ -14,7 +14,7 @@ export default function Tabs({ skirtukas, setSkirtukas, className = '' }) {
       </Button>
       <Button
         className="flex-1 text-center"
-        size="sm"
+        size="md"
         onClick={() => setSkirtukas('zurnalas')}
         variant={skirtukas==='zurnalas'?'default':'outline'}
       >
@@ -22,7 +22,7 @@ export default function Tabs({ skirtukas, setSkirtukas, className = '' }) {
       </Button>
       <Button
         className="flex-1 text-center"
-        size="sm"
+        size="md"
         onClick={() => setSkirtukas('analytics')}
         variant={skirtukas==='analytics'?'default':'outline'}
       >


### PR DESCRIPTION
## Summary
- use medium button size for nav tabs and filters to improve touch targets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc1c17469c832093b4ce1ca7505018