### PR TITLE
Add SVG icons for tabs and update tests

### DIFF
--- a/__tests__/Tabs.test.jsx
+++ b/__tests__/Tabs.test.jsx
@@ -14,6 +14,14 @@ describe('Tabs', () => {
     expect(setSkirtukas).toHaveBeenCalledWith(value);
   });
 
+  test('renders icons for all tabs', () => {
+    const setSkirtukas = jest.fn();
+    render(<Tabs skirtukas="lovos" setSkirtukas={setSkirtukas} />);
+    expect(screen.getByRole('img', { name: /lovos/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /žurnalas/i })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /analizė/i })).toBeInTheDocument();
+  });
+
   test('active tab has default variant', () => {
     const setSkirtukas = jest.fn();
     render(<Tabs skirtukas="analytics" setSkirtukas={setSkirtukas} />);

--- a/components/Tabs.jsx
+++ b/components/Tabs.jsx
@@ -1,31 +1,37 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
+import BedIcon from '@/components/icons/BedIcon.jsx';
+import LogIcon from '@/components/icons/LogIcon.jsx';
+import ChartIcon from '@/components/icons/ChartIcon.jsx';
 
 export default function Tabs({ skirtukas, setSkirtukas, className = '' }) {
   return (
     <div className={`flex gap-2 ${className}`}>
       <Button
-        className="flex-1 text-center"
+        className="flex-1 flex items-center justify-center"
         size="md"
         onClick={() => setSkirtukas('lovos')}
         variant={skirtukas==='lovos'?'default':'outline'}
       >
+        <BedIcon className="w-4 h-4 mr-1" />
         Lovos
       </Button>
       <Button
-        className="flex-1 text-center"
+        className="flex-1 flex items-center justify-center"
         size="md"
         onClick={() => setSkirtukas('zurnalas')}
         variant={skirtukas==='zurnalas'?'default':'outline'}
       >
+        <LogIcon className="w-4 h-4 mr-1" />
         Žurnalas
       </Button>
       <Button
-        className="flex-1 text-center"
+        className="flex-1 flex items-center justify-center"
         size="md"
         onClick={() => setSkirtukas('analytics')}
         variant={skirtukas==='analytics'?'default':'outline'}
       >
+        <ChartIcon className="w-4 h-4 mr-1" />
         Analizė
       </Button>
     </div>

--- a/components/icons/BedIcon.jsx
+++ b/components/icons/BedIcon.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function BedIcon({ className = '', ...props }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      role="img"
+      aria-label="Lovos"
+      className={className}
+      {...props}
+    >
+      <rect x="3" y="7" width="18" height="10" rx="2" />
+      <path d="M3 7V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v2" />
+    </svg>
+  );
+}

--- a/components/icons/ChartIcon.jsx
+++ b/components/icons/ChartIcon.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function ChartIcon({ className = '', ...props }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      role="img"
+      aria-label="Analizė"
+      className={className}
+      {...props}
+    >
+      <path d="M3 3v18h18" />
+      <path d="M7 16V9" />
+      <path d="M12 16V5" />
+      <path d="M17 16V12" />
+    </svg>
+  );
+}

--- a/components/icons/LogIcon.jsx
+++ b/components/icons/LogIcon.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function LogIcon({ className = '', ...props }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      role="img"
+      aria-label="Žurnalas"
+      className={className}
+      {...props}
+    >
+      <path d="M6 2h9l5 5v15H6z" />
+      <path d="M14 2v6h6" />
+      <path d="M9 13h6" />
+      <path d="M9 17h6" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add BedIcon, LogIcon, and ChartIcon React components
- render icons in Tabs component next to tab labels
- expand Tabs tests to verify icon presence and active styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc500feec883209d1c3cb1100cbc50