### PR TITLE
Add responsive mobile menus for filters and header

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -45,6 +45,13 @@ export default function LovuValdymoPrograma() {
   const [paieska,setPaieska]=useState('');
   const [dark,setDark]=useState(false);
   const [alertsMuted,setAlertsMuted]=useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [isMd, setIsMd] = useState(() => window.innerWidth >= 768);
+  useEffect(() => {
+    const onResize = () => setIsMd(window.innerWidth >= 768);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
   const alertedRef = useRef(new Set());
   const zoneRefs = useRef({});
 
@@ -133,18 +140,33 @@ export default function LovuValdymoPrograma() {
         onSelectZone={scrollToZone}
       />
       <main className="max-w-screen-2xl mx-auto p-2">
-        <nav className="flex flex-col md:flex-row gap-2 mb-1">
-          <Filters
-            filtras={filtras}
-            setFiltras={setFiltras}
-            FiltravimoRezimai={FiltravimoRezimai}
-            className="flex-1 md:flex-[4]"
-          />
-          <Tabs
-            skirtukas={skirtukas}
-            setSkirtukas={setSkirtukas}
-            className="flex-1 md:flex-[3]"
-          />
+        <nav className="mb-1 flex flex-col">
+          {!isMd && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="mb-1 self-start md:hidden"
+              onClick={() => setMenuOpen(o => !o)}
+              aria-label="Meniu"
+            >
+              ☰
+            </Button>
+          )}
+          {(menuOpen || isMd) && (
+            <div className="flex flex-col md:flex-row gap-1">
+              <Filters
+                filtras={filtras}
+                setFiltras={setFiltras}
+                FiltravimoRezimai={FiltravimoRezimai}
+                className="flex-1 md:flex-[4]"
+              />
+              <Tabs
+                skirtukas={skirtukas}
+                setSkirtukas={setSkirtukas}
+                className="flex-1 md:flex-[3]"
+              />
+            </div>
+          )}
         </nav>
         {skirtukas==='lovos' && <StatusSummary statusMap={statusMap}/>}
         {skirtukas==='lovos' ? (

--- a/__tests__/LovuValdymoPrograma.test.jsx
+++ b/__tests__/LovuValdymoPrograma.test.jsx
@@ -111,4 +111,21 @@ describe('LovuValdymoPrograma', () => {
 
     expect(within(zone).queryByText(/^1$/)).not.toBeInTheDocument();
   });
+
+  test('mobile menu reveals filters and tabs', () => {
+    const originalWidth = window.innerWidth;
+    window.innerWidth = 500;
+    render(<LovuValdymoPrograma />);
+
+    expect(screen.queryByText('Filtrai')).toBeNull();
+    expect(screen.queryByText('Žurnalas')).toBeNull();
+
+    const menuBtn = screen.getAllByLabelText('Meniu')[1];
+    fireEvent.click(menuBtn);
+
+    expect(screen.getByText('Filtrai')).toBeInTheDocument();
+    expect(screen.getByText('Žurnalas')).toBeInTheDocument();
+
+    window.innerWidth = originalWidth;
+  });
 });

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -10,6 +10,13 @@ export default function Header({
   onSelectZone,
 }) {
   const [selected, setSelected] = React.useState('');
+  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [isSmall, setIsSmall] = React.useState(() => window.innerWidth < 640);
+  React.useEffect(() => {
+    const onResize = () => setIsSmall(window.innerWidth < 640);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
 
   const handleChange = e => {
     const value = e.target.value;
@@ -19,44 +26,62 @@ export default function Header({
     }
   };
 
+  const controls = (
+    <>
+      {zones.length > 0 && (
+        <select
+          value={selected}
+          onChange={handleChange}
+          className="glass border rounded px-2 py-1 text-sm bg-white/60 dark:bg-gray-900/60 text-gray-900 dark:text-gray-100"
+        >
+          <option value="" disabled>
+            Zonos
+          </option>
+          {zones.map(z => (
+            <option key={z} value={z}>
+              {z}
+            </option>
+          ))}
+        </select>
+      )}
+      <Button
+        size="sm"
+        variant="outline"
+        className="glass text-gray-900 dark:text-gray-100 hover:bg-white/40 dark:hover:bg-gray-900/40"
+        onClick={toggleMute}
+      >
+        {alertsMuted ? 'Unmute' : 'Mute'}
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        className="glass text-gray-900 dark:text-gray-100 hover:bg-white/40 dark:hover:bg-gray-900/40"
+        onClick={toggleDark}
+      >
+        {dark ? 'Light' : 'Dark'}
+      </Button>
+    </>
+  );
+
   return (
     <header className="glass text-gray-900 dark:text-gray-100 mb-2">
-      <div className="max-w-screen-2xl mx-auto px-4 py-2 flex items-center justify-between">
-        <h1 className="text-lg font-semibold">SPS lovų priežiūros programa</h1>
-        <div className="flex gap-2 items-center">
-          {zones.length > 0 && (
-            <select
-              value={selected}
-              onChange={handleChange}
-              className="glass border rounded px-2 py-1 text-sm bg-white/60 dark:bg-gray-900/60 text-gray-900 dark:text-gray-100"
+      <div className="max-w-screen-2xl mx-auto px-4 py-2 flex flex-col sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center justify-between">
+          <h1 className="text-lg font-semibold">SPS lovų priežiūros programa</h1>
+          {isSmall && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="sm:hidden"
+              onClick={() => setMenuOpen(o => !o)}
+              aria-label="Meniu"
             >
-              <option value="" disabled>
-                Zonos
-              </option>
-              {zones.map(z => (
-                <option key={z} value={z}>
-                  {z}
-                </option>
-              ))}
-            </select>
+              ☰
+            </Button>
           )}
-          <Button
-            size="sm"
-            variant="outline"
-            className="glass text-gray-900 dark:text-gray-100 hover:bg-white/40 dark:hover:bg-gray-900/40"
-            onClick={toggleMute}
-          >
-            {alertsMuted ? 'Unmute' : 'Mute'}
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            className="glass text-gray-900 dark:text-gray-100 hover:bg-white/40 dark:hover:bg-gray-900/40"
-            onClick={toggleDark}
-          >
-            {dark ? 'Light' : 'Dark'}
-          </Button>
         </div>
+        <div className="hidden sm:flex gap-2 items-center">{controls}</div>
+        {isSmall && menuOpen && <div className="sm:hidden flex flex-col gap-1 mt-2">{controls}</div>}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- Add state-controlled hamburger menu to toggle Filters and Tabs on small screens
- Move header controls into collapsible mobile menu
- Add unit test verifying mobile menu shows filters and tabs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc51ab4d5483208a1e9e642869e3e3