### PR TITLE
Improve navigation button sizing and filter icon

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -158,12 +158,12 @@ export default function LovuValdymoPrograma() {
                 filtras={filtras}
                 setFiltras={setFiltras}
                 FiltravimoRezimai={FiltravimoRezimai}
-                className="flex-1 md:flex-[4]"
+                className="w-full md:w-auto flex-none"
               />
               <Tabs
                 skirtukas={skirtukas}
                 setSkirtukas={setSkirtukas}
-                className="flex-1 md:flex-[3]"
+                className="flex-1"
               />
             </div>
           )}

--- a/components/Filters.jsx
+++ b/components/Filters.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { Filter } from 'lucide-react';
 
 export default function Filters({ filtras, setFiltras, FiltravimoRezimai, className = '' }) {
   const [open, setOpen] = useState(false);
@@ -18,7 +19,13 @@ export default function Filters({ filtras, setFiltras, FiltravimoRezimai, classN
 
   return (
     <div className={`relative ${className}`}>
-      <Button className="w-full" size="md" onClick={() => setOpen(o => !o)}>
+      <Button
+        size="sm"
+        onClick={() => setOpen(o => !o)}
+        className="flex items-center px-2 w-full md:w-auto"
+        aria-label="Filtrai"
+      >
+        <Filter className="w-4 h-4 mr-1" aria-hidden="true" />
         Filtrai
       </Button>
       {open && (

--- a/components/Tabs.jsx
+++ b/components/Tabs.jsx
@@ -8,8 +8,8 @@ export default function Tabs({ skirtukas, setSkirtukas, className = '' }) {
   return (
     <div className={`flex gap-2 ${className}`}>
       <Button
-        className="flex-1 flex items-center justify-center"
-        size="md"
+        className="flex-1 flex items-center justify-center px-4"
+        size="touch"
         onClick={() => setSkirtukas('lovos')}
         variant={skirtukas==='lovos'?'default':'outline'}
       >
@@ -17,8 +17,8 @@ export default function Tabs({ skirtukas, setSkirtukas, className = '' }) {
         Lovos
       </Button>
       <Button
-        className="flex-1 flex items-center justify-center"
-        size="md"
+        className="flex-1 flex items-center justify-center px-4"
+        size="touch"
         onClick={() => setSkirtukas('zurnalas')}
         variant={skirtukas==='zurnalas'?'default':'outline'}
       >
@@ -26,8 +26,8 @@ export default function Tabs({ skirtukas, setSkirtukas, className = '' }) {
         Žurnalas
       </Button>
       <Button
-        className="flex-1 flex items-center justify-center"
-        size="md"
+        className="flex-1 flex items-center justify-center px-4"
+        size="touch"
         onClick={() => setSkirtukas('analytics')}
         variant={skirtukas==='analytics'?'default':'outline'}
       >


### PR DESCRIPTION
## Summary
- Enlarge main tabs with touch-sized buttons
- Shrink filter control and add filter icon
- Adjust layout so filter button doesn't stretch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc6e67fd34832080c1573b1467327e