### PR TITLE
refactor: extract bed manager hook and navigation components

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -1,18 +1,16 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { DragDropContext } from 'react-beautiful-dnd';
-import { Button } from '@/components/ui/button';
 import Pranesimas from './Pranesimas.jsx';
 import useLocalStorageState from './hooks/useLocalStorageState.js';
 import useInterval from './hooks/useInterval.js';
-import Filters from './components/Filters.jsx';
-import Tabs from './components/Tabs.jsx';
 import ZoneSection from './components/ZoneSection.jsx';
 import Header from './components/Header.jsx';
 import StatusSummary from './components/StatusSummary.jsx';
 import Analytics from './components/Analytics.jsx';
-import { NUMATYTA_BUSENA, dabar, isOverdue, resetBedStatus } from '@/src/utils/bedState.js';
-import { exportLogToCsv } from '@/src/utils/exportCsv.js';
-import { filterLogEntries } from '@/src/utils/logFilter.js';
+import NavigationBar from './components/NavigationBar.jsx';
+import LogView from './components/LogView.jsx';
+import useBedManager from './hooks/useBedManager.js';
+import { NUMATYTA_BUSENA, dabar, isOverdue } from '@/src/utils/bedState.js';
 
 // ---------------- Konfigūracija -----------------
 const ZONOS = {
@@ -20,61 +18,57 @@ const ZONOS = {
   'B zona': ['9','10','11','12','13','14','15','16'],
   'IT zona': ['IT1','IT2','IT3','IT4']
 };
-const VISOS_LOVOS = Object.values(ZONOS).flat();
-
-// ------------- Tipai --------------------
 const FiltravimoRezimai = { VISI: 'VISI', TUALETAS: 'TUALETAS', VALYMAS: 'VALYMAS', UZDELTAS: 'UZDELTAS' };
 
-
-// ------------- Pagrindinis Komponentas ------------
 export default function LovuValdymoPrograma() {
-  const [statusMap,setStatusMap]=useLocalStorageState(
-    'lovuBusena',
-    Object.fromEntries(VISOS_LOVOS.map(b=>[b,{...NUMATYTA_BUSENA}]))
-  );
-  const [zonosLovos,setZonosLovos]=useLocalStorageState('zonosLovos',ZONOS);
-  const [zonuPadejejas,setZonuPadejejas]=useLocalStorageState(
-    'zonuPadejejas',
-    Object.fromEntries(Object.keys(ZONOS).map(z=>[z,'']))
-  );
-  const [filtras,setFiltras]=useState(FiltravimoRezimai.VISI);
-  const [,tick]=useState(0);
-  const [snack,setSnack]=useState(null);
-  const [skirtukas,setSkirtukas]=useState('lovos');
-  const [zurnalas,setZurnalas]=useLocalStorageState('lovuZurnalas',[]);
-  const [paieska,setPaieska]=useState('');
-  const [dark,setDark]=useState(false);
-  const [alertsMuted,setAlertsMuted]=useState(false);
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [isMd, setIsMd] = useState(() => window.innerWidth >= 768);
-  useEffect(() => {
-    const onResize = () => setIsMd(window.innerWidth >= 768);
-    window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
-  }, []);
+  const [filtras, setFiltras] = useState(FiltravimoRezimai.VISI);
+  const [, tick] = useState(0);
+  const [skirtukas, setSkirtukas] = useState('lovos');
+  const [zurnalas, setZurnalas] = useLocalStorageState('lovuZurnalas', []);
+  const [dark, setDark] = useState(false);
+  const [alertsMuted, setAlertsMuted] = useState(false);
   const alertedRef = useRef(new Set());
   const zoneRefs = useRef({});
 
-  useEffect(()=>{
+  const pushZurnalas = tekst =>
+    setZurnalas(l => [...l, { ts: dabar(), vartotojas: 'Anon', tekstas: tekst }].slice(-200));
+
+  const {
+    statusMap,
+    zonosLovos,
+    zonuPadejejas,
+    snack,
+    toggleWC,
+    toggleCleaning,
+    markChecked,
+    resetLova,
+    checkAll,
+    undo,
+    handleZone,
+    onDragEnd,
+    setZonosLovos,
+  } = useBedManager(ZONOS, pushZurnalas);
+
+  useEffect(() => {
     const lovos = Object.values(zonosLovos).flat();
-    const legacy = lovos.some(v=>/[PS]/.test(v));
-    const mismatch = Object.entries(ZONOS).some(([z,b])=>{
+    const legacy = lovos.some(v => /[PS]/.test(v));
+    const mismatch = Object.entries(ZONOS).some(([z, b]) => {
       const cur = zonosLovos[z];
-      return !cur || cur.length!==b.length;
+      return !cur || cur.length !== b.length;
     });
-    if(legacy||mismatch){
+    if (legacy || mismatch) {
       setZonosLovos(ZONOS);
       localStorage.removeItem('lovuBusena');
       localStorage.removeItem('lovuZurnalas');
       localStorage.removeItem('zonuPadejejas');
     }
-  },[zonosLovos,ZONOS]);
+  }, [zonosLovos, setZonosLovos]);
 
-  useEffect(()=>{document.documentElement.classList.toggle('dark',dark);},[dark]);
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', dark);
+  }, [dark]);
 
   useInterval(() => tick(x => x + 1), 1000);
-
-  const pushZurnalas=tekst=>setZurnalas(l=>[...l,{ts:dabar(),vartotojas:'Anon',tekstas:tekst}].slice(-200));
 
   useEffect(() => {
     Object.entries(statusMap).forEach(([lova, s]) => {
@@ -88,7 +82,6 @@ export default function LovuValdymoPrograma() {
             if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
               new Notification(`Lova ${lova} pradelsta`);
             } else {
-              // Fallback garso signalas
               const a = new Audio('/beep.mp3');
               a.play().catch(() => {});
             }
@@ -101,22 +94,15 @@ export default function LovuValdymoPrograma() {
       }
     });
   }, [tick, statusMap, alertsMuted]);
-  const applyFilter=lov=>{
-    const s=statusMap[lov]||NUMATYTA_BUSENA;
-    if(filtras===FiltravimoRezimai.TUALETAS) return s.needsWC;
-    if(filtras===FiltravimoRezimai.VALYMAS) return s.needsCleaning;
-    if(filtras===FiltravimoRezimai.UZDELTAS) return isOverdue(s.lastCheckedAt);
+
+  const applyFilter = lov => {
+    const s = statusMap[lov] || NUMATYTA_BUSENA;
+    if (filtras === FiltravimoRezimai.TUALETAS) return s.needsWC;
+    if (filtras === FiltravimoRezimai.VALYMAS) return s.needsCleaning;
+    if (filtras === FiltravimoRezimai.UZDELTAS) return isOverdue(s.lastCheckedAt);
     return true;
   };
-  const updateLova=(lova,fn,msg)=>{setStatusMap(prev=>{const old=prev[lova]||NUMATYTA_BUSENA;const next={...fn(old),lastBy:'Anon',lastAt:dabar()};setSnack({bed:lova,prev:old,msg});return{...prev,[lova]:next};});pushZurnalas(msg);};
-  const toggleWC=b=>updateLova(b,s=>({...s,needsWC:!s.needsWC,lastWCAt:dabar(),flaggedAt:!s.needsWC?dabar():s.needsCleaning?s.flaggedAt:null}),`${b}: Tualetas`);
-  const toggleCleaning=b=>updateLova(b,s=>({...s,needsCleaning:!s.needsCleaning,lastCleanAt:dabar(),flaggedAt:!s.needsCleaning?dabar():s.needsWC?s.flaggedAt:null}),`${b}: Valymas`);
-  const markChecked=b=>updateLova(b,s=>({...s,lastCheckedAt:dabar()}),`${b}: Patikrinta`);
-  const resetLova=b=>{setStatusMap(prev=>{const old=prev[b]||NUMATYTA_BUSENA;const next=resetBedStatus();setSnack({bed:b,prev:old,msg:`${b}: Atstatyta`});return{...prev,[b]:next};});pushZurnalas(`${b}: Atstatyta`);};
-  const checkAll=z=>{const lovos=zonosLovos[z]||[];setStatusMap(prev=>{const upd={...prev};lovos.forEach(l=>{upd[l]={...upd[l],lastCheckedAt:dabar()}});return upd});pushZurnalas(`Zona ${z} patikrinta`);};
-  const undo=()=>{if(!snack)return;setStatusMap(p=>({...p,[snack.bed]:snack.prev}));setSnack(null);pushZurnalas(`Anuliuota ${snack.bed}`);};
-  const handleZone=(z,user)=>{setZonuPadejejas(prev=>{const next={...prev,[z]:user};pushZurnalas(`Padėjėjas ${user||'nėra'} ${z}`);return next;});const lovos=zonosLovos[z]||[];setStatusMap(prev=>{const upd={...prev};lovos.forEach(l=>{upd[l]={...upd[l],lastCheckedAt:dabar()}});return upd});};
-  const onDragEnd=res=>{if(!res.destination)return;const {source,destination,draggableId}=res;setZonosLovos(prev=>{const result={...prev};const src=Array.from(result[source.droppableId]);const [moved]=src.splice(source.index,1);if(source.droppableId===destination.droppableId){src.splice(destination.index,0,moved);result[source.droppableId]=src;}else{const dest=Array.from(result[destination.droppableId]);dest.splice(destination.index,0,moved);result[source.droppableId]=src;result[destination.droppableId]=dest;}return result;});pushZurnalas(`Perkelta ${draggableId} į ${destination.droppableId}`);};
+
   const scrollToZone = zona => {
     const el = zoneRefs.current[zona];
     if (el && el.scrollIntoView) {
@@ -127,9 +113,8 @@ export default function LovuValdymoPrograma() {
       }, 1500);
     }
   };
-  const filteredLog = filterLogEntries(zurnalas, paieska);
 
-  return(
+  return (
     <div className="min-h-screen bg-gradient-to-br from-slate-200 via-white to-slate-200 dark:from-gray-900 dark:via-gray-950 dark:to-gray-800">
       <Header
         dark={dark}
@@ -140,38 +125,17 @@ export default function LovuValdymoPrograma() {
         onSelectZone={scrollToZone}
       />
       <main className="max-w-screen-2xl mx-auto p-2">
-        <nav className="mb-1 flex flex-col">
-          {!isMd && (
-            <Button
-              size="sm"
-              variant="outline"
-              className="mb-1 self-start md:hidden"
-              onClick={() => setMenuOpen(o => !o)}
-              aria-label="Meniu"
-            >
-              ☰
-            </Button>
-          )}
-          {(menuOpen || isMd) && (
-            <div className="flex flex-col md:flex-row gap-1">
-              <Filters
-                filtras={filtras}
-                setFiltras={setFiltras}
-                FiltravimoRezimai={FiltravimoRezimai}
-                className="w-full md:w-auto flex-none"
-              />
-              <Tabs
-                skirtukas={skirtukas}
-                setSkirtukas={setSkirtukas}
-                className="flex-1"
-              />
-            </div>
-          )}
-        </nav>
-        {skirtukas==='lovos' && <StatusSummary statusMap={statusMap}/>}
-        {skirtukas==='lovos' ? (
+        <NavigationBar
+          filtras={filtras}
+          setFiltras={setFiltras}
+          FiltravimoRezimai={FiltravimoRezimai}
+          skirtukas={skirtukas}
+          setSkirtukas={setSkirtukas}
+        />
+        {skirtukas === 'lovos' && <StatusSummary statusMap={statusMap} />}
+        {skirtukas === 'lovos' ? (
           <DragDropContext onDragEnd={onDragEnd}>
-            {Object.entries(zonosLovos).map(([zona,lovos])=> (
+            {Object.entries(zonosLovos).map(([zona, lovos]) => (
               <ZoneSection
                 ref={el => (zoneRefs.current[zona] = el)}
                 key={zona}
@@ -184,30 +148,19 @@ export default function LovuValdymoPrograma() {
                 onCheck={markChecked}
                 onReset={resetLova}
                 padejejas={zonuPadejejas[zona]}
-                onPadejejasChange={user=>handleZone(zona,user)}
-                checkAll={()=>checkAll(zona)}
+                onPadejejasChange={user => handleZone(zona, user)}
+                checkAll={() => checkAll(zona)}
               />
             ))}
           </DragDropContext>
-        ) : skirtukas==='zurnalas' ? (
-          <div>
-            <div className="flex items-center gap-2 mb-1">
-              <input className="border p-1 rounded text-xs flex-1 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100" placeholder="Ieškoti žurnale" value={paieska} onChange={e=>setPaieska(e.target.value)}/>
-              <Button size="sm" onClick={() => exportLogToCsv(filteredLog)}>Eksportuoti CSV</Button>
-            </div>
-              <ul className="text-xs space-y-1 max-h-[70vh] overflow-auto">
-                {filteredLog.map(e => (
-                  <li key={e.ts} className="py-0.5">
-                    {e.vartotojas}[{new Date(e.ts).toLocaleTimeString()}]: {e.tekstas}
-                  </li>
-                ))}
-              </ul>
-          </div>
+        ) : skirtukas === 'zurnalas' ? (
+          <LogView log={zurnalas} />
         ) : (
-          <Analytics log={zurnalas}/>
+          <Analytics log={zurnalas} />
         )}
       </main>
-      {snack&&<Pranesimas msg={snack.msg} onUndo={undo}/>}
+      {snack && <Pranesimas msg={snack.msg} onUndo={undo} />}
     </div>
   );
 }
+

--- a/__tests__/useBedManager.test.js
+++ b/__tests__/useBedManager.test.js
@@ -1,0 +1,27 @@
+import { renderHook, act } from '@testing-library/react';
+import useBedManager from '../hooks/useBedManager.js';
+
+const ZONOS = { A: ['1'] };
+
+describe('useBedManager', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('toggleWC updates needsWC', () => {
+    const pushLog = jest.fn();
+    const { result } = renderHook(() => useBedManager(ZONOS, pushLog));
+    act(() => result.current.toggleWC('1'));
+    expect(result.current.statusMap['1'].needsWC).toBe(true);
+    expect(pushLog).toHaveBeenCalledWith('1: Tualetas');
+  });
+
+  test('undo restores previous state', () => {
+    const pushLog = jest.fn();
+    const { result } = renderHook(() => useBedManager(ZONOS, pushLog));
+    act(() => result.current.toggleWC('1'));
+    act(() => result.current.undo());
+    expect(result.current.statusMap['1'].needsWC).toBe(false);
+  });
+});
+

--- a/components/LogView.jsx
+++ b/components/LogView.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { exportLogToCsv } from '@/src/utils/exportCsv.js';
+import { filterLogEntries } from '@/src/utils/logFilter.js';
+
+export default function LogView({ log }) {
+  const [search, setSearch] = useState('');
+  const filteredLog = filterLogEntries(log, search);
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-1">
+        <input
+          className="border p-1 rounded text-xs flex-1 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+          placeholder="Ieškoti žurnale"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+        <Button size="sm" onClick={() => exportLogToCsv(filteredLog)}>
+          Eksportuoti CSV
+        </Button>
+      </div>
+      <ul className="text-xs space-y-1 max-h-[70vh] overflow-auto">
+        {filteredLog.map(e => (
+          <li key={e.ts} className="py-0.5">
+            {e.vartotojas}[{new Date(e.ts).toLocaleTimeString()}]: {e.tekstas}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/components/NavigationBar.jsx
+++ b/components/NavigationBar.jsx
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+import Filters from './Filters.jsx';
+import Tabs from './Tabs.jsx';
+import { Button } from '@/components/ui/button';
+
+export default function NavigationBar({ filtras, setFiltras, FiltravimoRezimai, skirtukas, setSkirtukas }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [isMd, setIsMd] = useState(() => window.innerWidth >= 768);
+
+  useEffect(() => {
+    const onResize = () => setIsMd(window.innerWidth >= 768);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  return (
+    <nav className="mb-1 flex flex-col">
+      {!isMd && (
+        <Button
+          size="sm"
+          variant="outline"
+          className="mb-1 self-start md:hidden"
+          onClick={() => setMenuOpen(o => !o)}
+          aria-label="Meniu"
+        >
+          ☰
+        </Button>
+      )}
+      {(menuOpen || isMd) && (
+        <div className="flex flex-col md:flex-row gap-1">
+          <Filters
+            filtras={filtras}
+            setFiltras={setFiltras}
+            FiltravimoRezimai={FiltravimoRezimai}
+            className="w-full md:w-auto flex-none"
+          />
+          <Tabs
+            skirtukas={skirtukas}
+            setSkirtukas={setSkirtukas}
+            className="flex-1"
+          />
+        </div>
+      )}
+    </nav>
+  );
+}
+

--- a/hooks/useBedManager.js
+++ b/hooks/useBedManager.js
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import useLocalStorageState from './useLocalStorageState.js';
+import { NUMATYTA_BUSENA, dabar, resetBedStatus } from '@/src/utils/bedState.js';
+
+export default function useBedManager(initialZones, pushLog) {
+  const VISOS_LOVOS = Object.values(initialZones).flat();
+  const [statusMap, setStatusMap] = useLocalStorageState(
+    'lovuBusena',
+    Object.fromEntries(VISOS_LOVOS.map(b => [b, { ...NUMATYTA_BUSENA }]))
+  );
+  const [zonosLovos, setZonosLovos] = useLocalStorageState('zonosLovos', initialZones);
+  const [zonuPadejejas, setZonuPadejejas] = useLocalStorageState(
+    'zonuPadejejas',
+    Object.fromEntries(Object.keys(initialZones).map(z => [z, '']))
+  );
+  const [snack, setSnack] = useState(null);
+
+  const updateBed = (bed, fn, msg) => {
+    setStatusMap(prev => {
+      const old = prev[bed] || NUMATYTA_BUSENA;
+      const next = { ...fn(old), lastBy: 'Anon', lastAt: dabar() };
+      setSnack({ bed, prev: old, msg });
+      return { ...prev, [bed]: next };
+    });
+    pushLog(msg);
+  };
+
+  const toggleWC = b =>
+    updateBed(
+      b,
+      s => ({
+        ...s,
+        needsWC: !s.needsWC,
+        lastWCAt: dabar(),
+        flaggedAt: !s.needsWC ? dabar() : s.needsCleaning ? s.flaggedAt : null,
+      }),
+      `${b}: Tualetas`
+    );
+
+  const toggleCleaning = b =>
+    updateBed(
+      b,
+      s => ({
+        ...s,
+        needsCleaning: !s.needsCleaning,
+        lastCleanAt: dabar(),
+        flaggedAt: !s.needsCleaning ? dabar() : s.needsWC ? s.flaggedAt : null,
+      }),
+      `${b}: Valymas`
+    );
+
+  const markChecked = b =>
+    updateBed(b, s => ({ ...s, lastCheckedAt: dabar() }), `${b}: Patikrinta`);
+
+  const resetLova = b => {
+    setStatusMap(prev => {
+      const old = prev[b] || NUMATYTA_BUSENA;
+      const next = resetBedStatus();
+      setSnack({ bed: b, prev: old, msg: `${b}: Atstatyta` });
+      return { ...prev, [b]: next };
+    });
+    pushLog(`${b}: Atstatyta`);
+  };
+
+  const checkAll = zona => {
+    const lovos = zonosLovos[zona] || [];
+    setStatusMap(prev => {
+      const upd = { ...prev };
+      lovos.forEach(l => {
+        upd[l] = { ...upd[l], lastCheckedAt: dabar() };
+      });
+      return upd;
+    });
+    pushLog(`Zona ${zona} patikrinta`);
+  };
+
+  const undo = () => {
+    if (!snack) return;
+    setStatusMap(p => ({ ...p, [snack.bed]: snack.prev }));
+    setSnack(null);
+    pushLog(`Anuliuota ${snack.bed}`);
+  };
+
+  const handleZone = (zona, user) => {
+    setZonuPadejejas(prev => {
+      const next = { ...prev, [zona]: user };
+      pushLog(`Padėjėjas ${user || 'nėra'} ${zona}`);
+      return next;
+    });
+    const lovos = zonosLovos[zona] || [];
+    setStatusMap(prev => {
+      const upd = { ...prev };
+      lovos.forEach(l => {
+        upd[l] = { ...upd[l], lastCheckedAt: dabar() };
+      });
+      return upd;
+    });
+  };
+
+  const onDragEnd = res => {
+    if (!res.destination) return;
+    const { source, destination, draggableId } = res;
+    setZonosLovos(prev => {
+      const result = { ...prev };
+      const src = Array.from(result[source.droppableId]);
+      const [moved] = src.splice(source.index, 1);
+      if (source.droppableId === destination.droppableId) {
+        src.splice(destination.index, 0, moved);
+        result[source.droppableId] = src;
+      } else {
+        const dest = Array.from(result[destination.droppableId]);
+        dest.splice(destination.index, 0, moved);
+        result[source.droppableId] = src;
+        result[destination.droppableId] = dest;
+      }
+      return result;
+    });
+    pushLog(`Perkelta ${draggableId} į ${destination.droppableId}`);
+  };
+
+  return {
+    statusMap,
+    zonosLovos,
+    zonuPadejejas,
+    snack,
+    toggleWC,
+    toggleCleaning,
+    markChecked,
+    resetLova,
+    checkAll,
+    undo,
+    handleZone,
+    onDragEnd,
+    setZonosLovos,
+  };
+}
+


### PR DESCRIPTION
## Summary
- add `useBedManager` hook to centralize bed status updates
- extract navigation and log UI into `NavigationBar` and `LogView` components
- simplify `LovuValdymoPrograma` composition and add hook tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bca47620f48320933014757165bfa9