### PR TITLE
Add PropTypes and prop validation tests

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
 import { DragDropContext } from 'react-beautiful-dnd';
 import Pranesimas from './Pranesimas.jsx';
 import useLocalStorageState from './hooks/useLocalStorageState.js';
@@ -20,7 +21,7 @@ const ZONOS = {
 };
 const FiltravimoRezimai = { VISI: 'VISI', TUALETAS: 'TUALETAS', VALYMAS: 'VALYMAS', UZDELTAS: 'UZDELTAS' };
 
-export default function LovuValdymoPrograma() {
+function LovuValdymoPrograma() {
   const [filtras, setFiltras] = useState(FiltravimoRezimai.VISI);
   const [, tick] = useState(0);
   const [skirtukas, setSkirtukas] = useState('lovos');
@@ -163,4 +164,10 @@ export default function LovuValdymoPrograma() {
     </div>
   );
 }
+
+LovuValdymoPrograma.propTypes = {};
+
+LovuValdymoPrograma.defaultProps = {};
+
+export default LovuValdymoPrograma;
 

--- a/__tests__/Filters.test.jsx
+++ b/__tests__/Filters.test.jsx
@@ -35,4 +35,20 @@ describe('Filters', () => {
     const other = options.find(o => o.label !== label);
     expect(screen.getByText(other.label)).toHaveClass('border-gray-300');
   });
+
+  test('uses default className and warns on invalid handler', () => {
+    const { container } = render(
+      <Filters filtras={FiltravimoRezimai.VISI} setFiltras={() => {}} FiltravimoRezimai={FiltravimoRezimai} />
+    );
+    const classes = container.firstChild.classList;
+    expect(classes.contains('relative')).toBe(true);
+    expect(classes.length).toBe(1);
+
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <Filters filtras={FiltravimoRezimai.VISI} setFiltras={42} FiltravimoRezimai={FiltravimoRezimai} />
+    );
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
 });

--- a/__tests__/Header.test.jsx
+++ b/__tests__/Header.test.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Header from '../components/Header.jsx';
+
+describe('Header', () => {
+  test('renders without zones when none provided', () => {
+    render(<Header />);
+    expect(screen.queryByText('Zonos')).toBeNull();
+  });
+
+  test('warns on invalid dark prop', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    render(<Header dark="true" />);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+

--- a/__tests__/Tabs.test.jsx
+++ b/__tests__/Tabs.test.jsx
@@ -29,4 +29,16 @@ describe('Tabs', () => {
     expect(screen.getByText('Lovos')).toHaveClass('border-gray-300');
     expect(screen.getByText('Žurnalas')).toHaveClass('border-gray-300');
   });
+
+  test('default className and invalid handler warning', () => {
+    const { container } = render(<Tabs skirtukas="lovos" setSkirtukas={() => {}} />);
+    const root = container.firstChild;
+    expect(root).toHaveClass('flex', 'gap-2');
+    expect(root.classList.length).toBe(2);
+
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    render(<Tabs skirtukas="lovos" setSkirtukas={42} />);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
 });

--- a/__tests__/ZoneSection.test.jsx
+++ b/__tests__/ZoneSection.test.jsx
@@ -108,3 +108,20 @@ describe('ZoneSection card layout', () => {
     });
   });
 });
+
+describe('ZoneSection props validation', () => {
+  afterEach(() => cleanup());
+
+  test('defaults padejejas to empty string', () => {
+    renderZone({ padejejas: undefined });
+    const input = screen.getByPlaceholderText('Padėjėjas');
+    expect(input.value).toBe('');
+  });
+
+  test('warns when zona is not a string', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    renderZone({ zona: 123 });
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/components/Filters.jsx
+++ b/components/Filters.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { Button } from '@/components/ui/button';
 import { Filter } from 'lucide-react';
 
-export default function Filters({ filtras, setFiltras, FiltravimoRezimai, className = '' }) {
+function Filters({ filtras, setFiltras, FiltravimoRezimai, className }) {
   const [open, setOpen] = useState(false);
 
   const handleSelect = mode => {
@@ -46,3 +47,16 @@ export default function Filters({ filtras, setFiltras, FiltravimoRezimai, classN
     </div>
   );
 }
+
+Filters.propTypes = {
+  filtras: PropTypes.string.isRequired,
+  setFiltras: PropTypes.func.isRequired,
+  FiltravimoRezimai: PropTypes.object.isRequired,
+  className: PropTypes.string,
+};
+
+Filters.defaultProps = {
+  className: '',
+};
+
+export default Filters;

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Button } from '@/components/ui/button';
 
-export default function Header({
+function Header({
   dark,
   toggleDark,
   alertsMuted,
   toggleMute,
-  zones = [],
+  zones,
   onSelectZone,
 }) {
   const [selected, setSelected] = React.useState('');
@@ -86,3 +87,23 @@ export default function Header({
     </header>
   );
 }
+
+Header.propTypes = {
+  dark: PropTypes.bool,
+  toggleDark: PropTypes.func,
+  alertsMuted: PropTypes.bool,
+  toggleMute: PropTypes.func,
+  zones: PropTypes.arrayOf(PropTypes.string),
+  onSelectZone: PropTypes.func,
+};
+
+Header.defaultProps = {
+  dark: false,
+  toggleDark: () => {},
+  alertsMuted: false,
+  toggleMute: () => {},
+  zones: [],
+  onSelectZone: null,
+};
+
+export default Header;

--- a/components/Tabs.jsx
+++ b/components/Tabs.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Button } from '@/components/ui/button';
 import BedIcon from '@/components/icons/BedIcon.jsx';
 import LogIcon from '@/components/icons/LogIcon.jsx';
 import ChartIcon from '@/components/icons/ChartIcon.jsx';
 
-export default function Tabs({ skirtukas, setSkirtukas, className = '' }) {
+function Tabs({ skirtukas, setSkirtukas, className }) {
   return (
     <div className={`flex gap-2 ${className}`}>
       <Button
@@ -37,3 +38,15 @@ export default function Tabs({ skirtukas, setSkirtukas, className = '' }) {
     </div>
   );
 }
+
+Tabs.propTypes = {
+  skirtukas: PropTypes.string.isRequired,
+  setSkirtukas: PropTypes.func.isRequired,
+  className: PropTypes.string,
+};
+
+Tabs.defaultProps = {
+  className: '',
+};
+
+export default Tabs;

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Droppable } from 'react-beautiful-dnd';
 import { Button } from '@/components/ui/button';
 import { Check, ChevronDown, ChevronRight } from 'lucide-react';
@@ -76,5 +77,23 @@ const ZoneSection = React.forwardRef(function ZoneSection({
     </div>
   );
 });
+
+ZoneSection.propTypes = {
+  zona: PropTypes.string.isRequired,
+  lovos: PropTypes.arrayOf(PropTypes.string).isRequired,
+  statusMap: PropTypes.object.isRequired,
+  applyFilter: PropTypes.func.isRequired,
+  onWC: PropTypes.func.isRequired,
+  onClean: PropTypes.func.isRequired,
+  onCheck: PropTypes.func.isRequired,
+  onReset: PropTypes.func.isRequired,
+  padejejas: PropTypes.string,
+  onPadejejasChange: PropTypes.func.isRequired,
+  checkAll: PropTypes.func.isRequired,
+};
+
+ZoneSection.defaultProps = {
+  padejejas: '',
+};
 
 export default ZoneSection;


### PR DESCRIPTION
## Summary
- add `prop-types` definitions and sensible defaults for core components
- validate component props with new tests including header coverage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd0779b1808320ad2fb134b24ed129