### PR TITLE
Skip drag-and-drop on touch devices

### DIFF
--- a/LovuValdymoPrograma.jsx
+++ b/LovuValdymoPrograma.jsx
@@ -30,6 +30,7 @@ function LovuValdymoPrograma() {
   const [alertsMuted, setAlertsMuted] = useState(false);
   const alertedRef = useRef(new Set());
   const zoneRefs = useRef({});
+  const [isTouch, setIsTouch] = useState(false);
 
   const pushZurnalas = tekst =>
     setZurnalas(l => [...l, { ts: dabar(), vartotojas: 'Anon', tekstas: tekst }].slice(-200));
@@ -70,6 +71,20 @@ function LovuValdymoPrograma() {
   }, [dark]);
 
   useInterval(() => tick(x => x + 1), 1000);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+      const mq = window.matchMedia('(pointer: coarse)');
+      setIsTouch(mq.matches);
+      const handler = e => setIsTouch(e.matches);
+      if (mq.addEventListener) mq.addEventListener('change', handler);
+      else mq.addListener(handler);
+      return () => {
+        if (mq.removeEventListener) mq.removeEventListener('change', handler);
+        else mq.removeListener(handler);
+      };
+    }
+  }, []);
 
   useEffect(() => {
     Object.entries(statusMap).forEach(([lova, s]) => {
@@ -135,8 +150,8 @@ function LovuValdymoPrograma() {
         />
         {skirtukas === 'lovos' && <StatusSummary statusMap={statusMap} />}
         {skirtukas === 'lovos' ? (
-          <DragDropContext onDragEnd={onDragEnd}>
-            {Object.entries(zonosLovos).map(([zona, lovos]) => (
+          isTouch ? (
+            Object.entries(zonosLovos).map(([zona, lovos]) => (
               <ZoneSection
                 ref={el => (zoneRefs.current[zona] = el)}
                 key={zona}
@@ -151,9 +166,31 @@ function LovuValdymoPrograma() {
                 padejejas={zonuPadejejas[zona]}
                 onPadejejasChange={user => handleZone(zona, user)}
                 checkAll={() => checkAll(zona)}
+                isTouch={isTouch}
               />
-            ))}
-          </DragDropContext>
+            ))
+          ) : (
+            <DragDropContext onDragEnd={onDragEnd}>
+              {Object.entries(zonosLovos).map(([zona, lovos]) => (
+                <ZoneSection
+                  ref={el => (zoneRefs.current[zona] = el)}
+                  key={zona}
+                  zona={zona}
+                  lovos={lovos}
+                  statusMap={statusMap}
+                  applyFilter={applyFilter}
+                  onWC={toggleWC}
+                  onClean={toggleCleaning}
+                  onCheck={markChecked}
+                  onReset={resetLova}
+                  padejejas={zonuPadejejas[zona]}
+                  onPadejejasChange={user => handleZone(zona, user)}
+                  checkAll={() => checkAll(zona)}
+                  isTouch={false}
+                />
+              ))}
+            </DragDropContext>
+          )
         ) : skirtukas === 'zurnalas' ? (
           <LogView log={zurnalas} />
         ) : (

--- a/components/LovosKortele.jsx
+++ b/components/LovosKortele.jsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Toilet, SprayCan, Check, RotateCcw } from 'lucide-react';
 import { NUMATYTA_BUSENA, laikasFormatu, isOverdue } from '@/src/utils/bedState.js';
 
-const LovosKortele = React.memo(function LovosKortele({ lova, index, status, onWC, onClean, onCheck, onReset }) {
+const LovosKortele = React.memo(function LovosKortele({ lova, index, status, onWC, onClean, onCheck, onReset, isTouch }) {
   const s = status || NUMATYTA_BUSENA;
   const gesture = useSwipeable({
     onSwipedLeft: () => onWC(lova),
@@ -28,78 +28,85 @@ const LovosKortele = React.memo(function LovosKortele({ lova, index, status, onW
         ? 'border-2 border-green-400 bg-green-100 text-green-800 animate-pulse dark:bg-green-900 dark:text-green-100 dark:border-green-400'
         : 'bg-gray-200 dark:bg-gray-700 dark:text-gray-100';
 
-  return (
+  const card = (
+    <Card
+      {...gesture}
+      className={`flex flex-col p-1 w-full min-h-20 sm:min-h-24 h-auto hover:scale-105 transition-transform ${rysys}`}
+      title={s.lastBy ? `${s.lastBy} • ${new Date(s.lastAt).toLocaleTimeString()}` : ''}
+    >
+      <CardHeader className="p-1 flex justify-center">
+        <span className="text-sm leading-tight">{lova}</span>
+      </CardHeader>
+      <CardContent className="p-1 flex flex-col items-center flex-1 space-y-0.5">
+        {s.lastCheckedAt && (
+          <span className="text-xs">Patikrinta: {laikasFormatu(s.lastCheckedAt)}</span>
+        )}
+        {s.lastWCAt && (
+          <span className="text-xs">Tual.: {laikasFormatu(s.lastWCAt)}</span>
+        )}
+        {s.lastCleanAt && (
+          <span className="text-xs">Val.: {laikasFormatu(s.lastCleanAt)}</span>
+        )}
+      </CardContent>
+      <CardFooter className="p-1 flex gap-1 justify-center">
+        <Button
+          size="icon-sm"
+          variant={s.needsWC ? 'warning' : 'outline'}
+          aria-label="Mark toilet needed"
+          onClick={e => {
+            e.stopPropagation();
+            onWC(lova);
+          }}
+        >
+          <Toilet size={20}/>
+        </Button>
+        <Button
+          size="icon-sm"
+          variant={s.needsCleaning ? 'warning' : 'outline'}
+          aria-label="Mark cleaned"
+          onClick={e => {
+            e.stopPropagation();
+            onClean(lova);
+          }}
+        >
+          <SprayCan size={20}/>
+        </Button>
+        <Button
+          size="icon-sm"
+          variant={pradelsta ? 'warning' : 'success'}
+          aria-label="Mark checked"
+          onClick={e => {
+            e.stopPropagation();
+            onCheck(lova);
+          }}
+        >
+          <Check size={20}/>
+        </Button>
+        <Button
+          size="icon-sm"
+          variant="outline"
+          aria-label="Reset status"
+          onClick={e => {
+            e.stopPropagation();
+            onReset(lova);
+          }}
+        >
+          <RotateCcw size={20}/>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+
+  return isTouch ? (
+    card
+  ) : (
     <Draggable draggableId={lova} index={index}>
       {provided => (
-        <Card
-          {...gesture}
-          ref={provided.innerRef}
-          {...provided.draggableProps}
-          {...provided.dragHandleProps}
-          className={`flex flex-col p-1 w-full min-h-20 sm:min-h-24 h-auto hover:scale-105 transition-transform ${rysys}`}
-          title={s.lastBy ? `${s.lastBy} • ${new Date(s.lastAt).toLocaleTimeString()}` : ''}
-        >
-          <CardHeader className="p-1 flex justify-center">
-            <span className="text-sm leading-tight">{lova}</span>
-          </CardHeader>
-          <CardContent className="p-1 flex flex-col items-center flex-1 space-y-0.5">
-            {s.lastCheckedAt && (
-              <span className="text-xs">Patikrinta: {laikasFormatu(s.lastCheckedAt)}</span>
-            )}
-            {s.lastWCAt && (
-              <span className="text-xs">Tual.: {laikasFormatu(s.lastWCAt)}</span>
-            )}
-            {s.lastCleanAt && (
-              <span className="text-xs">Val.: {laikasFormatu(s.lastCleanAt)}</span>
-            )}
-          </CardContent>
-          <CardFooter className="p-1 flex gap-1 justify-center">
-            <Button
-              size="icon-sm"
-              variant={s.needsWC ? 'warning' : 'outline'}
-              aria-label="Mark toilet needed"
-              onClick={e => {
-                e.stopPropagation();
-                onWC(lova);
-              }}
-            >
-              <Toilet size={20}/>
-            </Button>
-            <Button
-              size="icon-sm"
-              variant={s.needsCleaning ? 'warning' : 'outline'}
-              aria-label="Mark cleaned"
-              onClick={e => {
-                e.stopPropagation();
-                onClean(lova);
-              }}
-            >
-              <SprayCan size={20}/>
-            </Button>
-            <Button
-              size="icon-sm"
-              variant={pradelsta ? 'warning' : 'success'}
-              aria-label="Mark checked"
-              onClick={e => {
-                e.stopPropagation();
-                onCheck(lova);
-              }}
-            >
-              <Check size={20}/>
-            </Button>
-            <Button
-              size="icon-sm"
-              variant="outline"
-              aria-label="Reset status"
-              onClick={e => {
-                e.stopPropagation();
-                onReset(lova);
-              }}
-            >
-              <RotateCcw size={20}/>
-            </Button>
-          </CardFooter>
-        </Card>
+        React.cloneElement(card, {
+          ref: provided.innerRef,
+          ...provided.draggableProps,
+          ...provided.dragHandleProps,
+        })
       )}
     </Draggable>
   );

--- a/components/ZoneSection.jsx
+++ b/components/ZoneSection.jsx
@@ -17,6 +17,7 @@ const ZoneSection = React.forwardRef(function ZoneSection({
   padejejas,
   onPadejejasChange,
   checkAll,
+  isTouch,
 }, ref) {
   const [expanded, setExpanded] = React.useState(true);
 
@@ -50,29 +51,47 @@ const ZoneSection = React.forwardRef(function ZoneSection({
         </Button>
       </div>
       {expanded && (
-        <Droppable droppableId={zona}>
-          {provided => (
-            <div
-              ref={provided.innerRef}
-              {...provided.droppableProps}
-              className="grid grid-cols-[repeat(auto-fit,minmax(7rem,1fr))] sm:grid-cols-[repeat(auto-fit,minmax(8rem,1fr))] md:grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] lg:grid-cols-[repeat(auto-fit,minmax(10rem,1fr))] gap-1"
-            >
-              {lovos.filter(applyFilter).map((l, i) => (
-                <LovosKortele
-                  key={l}
-                  index={i}
-                  lova={l}
-                  status={statusMap[l]}
-                  onWC={onWC}
-                  onClean={onClean}
-                  onCheck={onCheck}
-                  onReset={onReset}
-                />
-              ))}
-              {provided.placeholder}
-            </div>
-          )}
-        </Droppable>
+        isTouch ? (
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(7rem,1fr))] sm:grid-cols-[repeat(auto-fit,minmax(8rem,1fr))] md:grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] lg:grid-cols-[repeat(auto-fit,minmax(10rem,1fr))] gap-1">
+            {lovos.filter(applyFilter).map((l, i) => (
+              <LovosKortele
+                key={l}
+                index={i}
+                lova={l}
+                status={statusMap[l]}
+                onWC={onWC}
+                onClean={onClean}
+                onCheck={onCheck}
+                onReset={onReset}
+                isTouch
+              />
+            ))}
+          </div>
+        ) : (
+          <Droppable droppableId={zona}>
+            {provided => (
+              <div
+                ref={provided.innerRef}
+                {...provided.droppableProps}
+                className="grid grid-cols-[repeat(auto-fit,minmax(7rem,1fr))] sm:grid-cols-[repeat(auto-fit,minmax(8rem,1fr))] md:grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] lg:grid-cols-[repeat(auto-fit,minmax(10rem,1fr))] gap-1"
+              >
+                {lovos.filter(applyFilter).map((l, i) => (
+                  <LovosKortele
+                    key={l}
+                    index={i}
+                    lova={l}
+                    status={statusMap[l]}
+                    onWC={onWC}
+                    onClean={onClean}
+                    onCheck={onCheck}
+                    onReset={onReset}
+                  />
+                ))}
+                {provided.placeholder}
+              </div>
+            )}
+          </Droppable>
+        )
       )}
     </div>
   );
@@ -90,10 +109,12 @@ ZoneSection.propTypes = {
   padejejas: PropTypes.string,
   onPadejejasChange: PropTypes.func.isRequired,
   checkAll: PropTypes.func.isRequired,
+  isTouch: PropTypes.bool,
 };
 
 ZoneSection.defaultProps = {
   padejejas: '',
+  isTouch: false,
 };
 
 export default ZoneSection;


### PR DESCRIPTION
## Summary
- Detect coarse pointer devices and set `isTouch` state
- Render static bed lists without DragDropContext/Draggable on touch hardware
- Keep bed status buttons functional so taps still update states

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd518715248320bc9dcfd281ad2b8a