### PR TITLE
Remove heavy bed card animations

### DIFF
--- a/__tests__/ZoneSection.test.jsx
+++ b/__tests__/ZoneSection.test.jsx
@@ -75,19 +75,19 @@ describe('ZoneSection collapse toggle', () => {
   });
 });
 
-describe('ZoneSection overdue animation', () => {
+describe('ZoneSection overdue styling', () => {
   afterEach(() => cleanup());
 
-  test('beds without last check do not animate', () => {
+  test('beds without last check use default styling', () => {
     renderZone();
     const card = screen.getByText('1').closest('.bg-gray-200');
-    expect(card).not.toHaveClass('animate-pulse');
+    expect(card).not.toHaveClass('border-red-500');
   });
 
-  test('beds pulse after exceeding limit', () => {
+  test('beds show red styling after exceeding limit', () => {
     renderZone({ statusMap: { '1': { lastCheckedAt: Date.now() - 31 * 60 * 1000 } } });
     const card = screen.getByText('1').closest('.bg-red-100');
-    expect(card).toHaveClass('animate-pulse');
+    expect(card).toHaveClass('border-red-500');
   });
 });
 

--- a/components/LovosKortele.jsx
+++ b/components/LovosKortele.jsx
@@ -23,15 +23,15 @@ const LovosKortele = React.memo(function LovosKortele({ lova, index, status, onW
   const rysys = lova.startsWith('IT')
     ? 'border-2 border-blue-400 bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100'
     : pradelsta
-      ? 'animate-pulse border-2 border-red-500 bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100 dark:border-red-400'
+      ? 'border-2 border-red-500 bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100 dark:border-red-400'
       : s.needsWC || s.needsCleaning
-        ? 'border-2 border-green-400 bg-green-100 text-green-800 animate-pulse dark:bg-green-900 dark:text-green-100 dark:border-green-400'
+        ? 'border-2 border-green-400 bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100 dark:border-green-400'
         : 'bg-gray-200 dark:bg-gray-700 dark:text-gray-100';
 
   const card = (
     <Card
       {...gesture}
-      className={`flex flex-col p-1 w-full min-h-20 sm:min-h-24 h-auto hover:scale-105 transition-transform ${rysys}`}
+      className={`flex flex-col p-1 w-full min-h-20 sm:min-h-24 h-auto motion-safe:hover:scale-105 motion-safe:transition-transform ${rysys}`}
       title={s.lastBy ? `${s.lastBy} • ${new Date(s.lastAt).toLocaleTimeString()}` : ''}
     >
       <CardHeader className="p-1 flex justify-center">


### PR DESCRIPTION
## Summary
- Remove animate-pulse and guard hover scaling with motion-safe
- Update overdue styling test to assert color-based status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd7d6920088320b804b2f683348b04